### PR TITLE
re #16 - started working on a compaction strategy for the metrics data

### DIFF
--- a/server/src/main/java/timely/api/model/Metric.java
+++ b/server/src/main/java/timely/api/model/Metric.java
@@ -1,11 +1,11 @@
 package timely.api.model;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.accumulo.core.client.lexicoder.DoubleLexicoder;
 import org.apache.accumulo.core.client.lexicoder.LongLexicoder;
 import org.apache.accumulo.core.client.lexicoder.PairLexicoder;
 import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
@@ -34,10 +34,23 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @WebSocket(operation = "put")
 public class Metric implements TcpRequest, HttpPostRequest, WebSocketRequest {
 
+    private static final ThreadLocal<ByteBuffer> WRITE_BUFFER = new ThreadLocal<ByteBuffer>() {
+
+        @Override
+        protected ByteBuffer initialValue() {
+            return ByteBuffer.allocate(Double.BYTES);
+        }
+    };
+    private static final ThreadLocal<ByteBuffer> READ_BUFFER = new ThreadLocal<ByteBuffer>() {
+
+        @Override
+        protected ByteBuffer initialValue() {
+            return ByteBuffer.allocate(Double.BYTES);
+        }
+    };
+
     private static final PairLexicoder<String, Long> rowCoder = new PairLexicoder<>(new StringLexicoder(),
             new LongLexicoder());
-    private static final DoubleLexicoder valueCoder = new DoubleLexicoder();
-
     public static final ColumnVisibility EMPTY_VISIBILITY = new ColumnVisibility();
     private static final String VISIBILITY_TAG = "viz=";
     private static final int VISIBILITY_TAG_LENGTH = VISIBILITY_TAG.length();
@@ -109,7 +122,9 @@ public class Metric implements TcpRequest, HttpPostRequest, WebSocketRequest {
 
     public Mutation toMutation() {
         final byte[] row = rowCoder.encode(new ComparablePair<String, Long>(this.metric, this.timestamp));
-        final Value value = new Value(valueCoder.encode(this.value));
+        WRITE_BUFFER.get().clear();
+        WRITE_BUFFER.get().putDouble(this.value);
+        final Value value = new Value(WRITE_BUFFER.get().array());
         final Mutation m = new Mutation(row);
         Collections.sort(tags);
         for (final Tag entry : tags) {
@@ -129,7 +144,10 @@ public class Metric implements TcpRequest, HttpPostRequest, WebSocketRequest {
 
     public static Metric parse(Key k, Value v) {
         ComparablePair<String, Long> row = rowCoder.decode(k.getRow().getBytes());
-        Double value = valueCoder.decode(v.get());
+        READ_BUFFER.get().clear();
+        READ_BUFFER.get().put(v.get());
+        READ_BUFFER.get().position(0);
+        Double value = READ_BUFFER.get().getDouble();
         Metric m = new Metric();
         m.setMetric(row.getFirst());
         m.setTimestamp(row.getSecond());
@@ -143,6 +161,10 @@ public class Metric implements TcpRequest, HttpPostRequest, WebSocketRequest {
         }
         m.setValue(value);
         return m;
+    }
+
+    public static ComparablePair<String, Long> decodeRowKey(byte[] row) {
+        return rowCoder.decode(row);
     }
 
     public static byte[] encodeRowKey(String metric, Long timestamp) {

--- a/server/src/main/java/timely/store/iterators/DataPointsCompactionIterator.java
+++ b/server/src/main/java/timely/store/iterators/DataPointsCompactionIterator.java
@@ -1,0 +1,49 @@
+package timely.store.iterators;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+/**
+ * Iterator designed to compact the metric timestamp and value data points into
+ * an interleaved timestamp (long) and metric value (double) byte array.
+ *
+ */
+public class DataPointsCompactionIterator extends TimeWindowCombiner {
+
+    @Override
+    public Value reduce(Key key, Iterator<KeyValuePair> iter) {
+        final AtomicInteger numValues = new AtomicInteger(0);
+        // Use a map to re-sort all of the timestamp/values in this time window.
+        Map<Long, byte[]> values = new TreeMap<>();
+        // Add all of the timestamp and values to the map, keeping track of the
+        // number of pairs
+        iter.forEachRemaining(kvp -> {
+            byte[] tmp = kvp.getValue().get();
+
+            if (tmp.length == Double.BYTES) {
+                numValues.incrementAndGet();
+            } else if (tmp.length % (DataPointsExpansionIterator.TIME_VALUE_LENGTH) == 0) {
+                numValues.addAndGet(tmp.length / DataPointsExpansionIterator.TIME_VALUE_LENGTH);
+            } else {
+                throw new RuntimeException("Incorrect number of bytes. " + tmp.length + " not a multiple of "
+                        + DataPointsExpansionIterator.TIME_VALUE_LENGTH);
+            }
+            values.put(kvp.getKey().getTimestamp(), tmp);
+        });
+
+        // Write out a new combined value.
+        ByteBuffer buf = ByteBuffer.allocate(numValues.get() * (DataPointsExpansionIterator.TIME_VALUE_LENGTH));
+        values.forEach((k, v) -> {
+            buf.putLong(k);
+            buf.put(v);
+        });
+        return new Value(buf.array());
+    }
+
+}

--- a/server/src/main/java/timely/store/iterators/DataPointsExpansionIterator.java
+++ b/server/src/main/java/timely/store/iterators/DataPointsExpansionIterator.java
@@ -1,0 +1,128 @@
+package timely.store.iterators;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.WrappingIterator;
+import org.apache.accumulo.core.util.Pair;
+
+import timely.api.model.Metric;
+
+/**
+ * Accumulo Iterator that expands the compacted Metric timestamps and values at
+ * scan time
+ *
+ */
+public class DataPointsExpansionIterator extends WrappingIterator {
+
+    public static final int TIME_VALUE_LENGTH = Long.BYTES + Double.BYTES;
+
+    private ByteBuffer timesAndValues = null;
+    private ByteBuffer metricValue = ByteBuffer.allocate(Double.BYTES);
+    private Key startKey = null;
+    private WritableKey workKey = null;
+    private Key k = null;
+    private Value v = new Value();
+    private Range range = null;
+
+    @Override
+    public Key getTopKey() {
+        if (null != k) {
+            return k;
+        }
+        return super.getTopKey();
+    }
+
+    @Override
+    public Value getTopValue() {
+        if (null != k) {
+            return v;
+        }
+        return super.getTopValue();
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (null == timesAndValues || timesAndValues.remaining() == 0) {
+            super.next();
+            if (super.hasTop()) {
+                startKey = super.getTopKey();
+                workKey.set(startKey);
+                timesAndValues = ByteBuffer.wrap(super.getTopValue().get());
+                k = decode(startKey, timesAndValues, v);
+            } else {
+                k = null;
+            }
+        } else {
+            k = decode(startKey, timesAndValues, v);
+        }
+        while (k != null && v != null && range.afterEndKey(k)) {
+            k = decode(startKey, timesAndValues, v);
+        }
+    }
+
+    private Key decode(Key startKey, ByteBuffer data, Value value) throws IOException {
+        Key key = null;
+        if (data.remaining() == 0) {
+            key = null;
+            value = null;
+        } else if (data.remaining() == Double.BYTES) {
+            // This value only contains a double
+            key = workKey;
+            value.set(data.array());
+            data.position(8); // simulate that we read from the array
+        } else if (data.remaining() >= TIME_VALUE_LENGTH) {
+            // This should be a Timestamp following by a metric value
+            Long timestamp = data.getLong();
+            Pair<String, Long> r = Metric.decodeRowKey(workKey.getRow().getBytes());
+            workKey.setRow(Metric.encodeRowKey(r.getFirst(), timestamp));
+            workKey.setTimestamp(timestamp);
+            key = workKey;
+            metricValue.clear();
+            data.get(metricValue.array()); // Read Double.BYTES from the Value
+                                           // byte array
+            metricValue.position(0);
+            value.set(metricValue.array());
+        } else {
+            throw new IOException("Incorrect number of bytes remaining. Expected >= " + TIME_VALUE_LENGTH + ", is: "
+                    + data.remaining());
+        }
+        return key;
+    }
+
+    @Override
+    public boolean hasTop() {
+        if (null != k) {
+            return true;
+        }
+        return super.hasTop();
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        super.seek(range, columnFamilies, inclusive);
+        this.range = range;
+        if (range.getStartKey() != null) {
+            while (hasTop() && getTopKey().equals(range.getStartKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)
+                    && getTopKey().getTimestamp() > range.getStartKey().getTimestamp()) {
+                next();
+            }
+            while (hasTop() && range.beforeStartKey(getTopKey())) {
+                next();
+            }
+        }
+        if (super.hasTop()) {
+            startKey = super.getTopKey();
+            workKey = new WritableKey(startKey);
+            timesAndValues = ByteBuffer.wrap(super.getTopValue().get());
+            k = decode(startKey, timesAndValues, v);
+        }
+    }
+
+}

--- a/server/src/main/java/timely/store/iterators/KeyValuePair.java
+++ b/server/src/main/java/timely/store/iterators/KeyValuePair.java
@@ -1,0 +1,36 @@
+package timely.store.iterators;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+public class KeyValuePair {
+
+    protected Key key;
+    protected Value value;
+
+    public Key getKey() {
+        return key;
+    }
+
+    public Value getValue() {
+        return value;
+    }
+
+    public void setKey(Key f) {
+        this.key = f;
+    }
+
+    public void setValue(Value s) {
+        this.value = s;
+    }
+
+    public void empty() {
+        this.key = null;
+        this.value = null;
+    }
+
+    public boolean isEmpty() {
+        return (this.key == null && this.value == null);
+    }
+
+}

--- a/server/src/main/java/timely/store/iterators/LookaheadIterator.java
+++ b/server/src/main/java/timely/store/iterators/LookaheadIterator.java
@@ -1,0 +1,148 @@
+package timely.store.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+/**
+ * Accumulo iterator that wraps another iterator and implements a lookahead
+ * feature. As you are iterating over the keys and values, you can peek ahead to
+ * the next key/value. Be aware that calling {@link #next()} after
+ * {@link #peek()} will return the same key and value. Additionally, you must
+ * consume both the key and value after calling {@link #next()} to clear the
+ * internal state. Example usage:
+ * 
+ * <pre>
+ * LookaheadIterator iter = new LookaheadIterator(source);
+ * iter.seek();
+ * iter.hasTop();
+ * iter.getTopKey();
+ * iter.getTopValue();
+ * 
+ * // Lookahead at the next key/value
+ * KeyValuePair lookahead = iter.peek();
+ * lookahead.getKey();
+ * lookahead.getValue();
+ * 
+ * // Move ahead to the next value, which is really the last value because of the
+ * // peek.
+ * iter.next();
+ * iter.hasTop();
+ * iter.getTopKey();
+ * iter.getTopValue(); // must call getTopKey and getTopValue after a peek to clear
+ * // the internal state
+ * 
+ * iter.next();
+ * iter.hasTop();
+ * iter.getTopKey();
+ * iter.getTopValue();
+ * </pre>
+ */
+public class LookaheadIterator implements SortedKeyValueIterator<Key, Value> {
+
+    private final SortedKeyValueIterator<Key, Value> source;
+    private KeyValuePair lookahead = new KeyValuePair();
+    private volatile boolean sourceEmpty = false;
+
+    public LookaheadIterator(SortedKeyValueIterator<Key, Value> source) {
+        this.source = source;
+    }
+
+    public SortedKeyValueIterator<Key, Value> getSource() {
+        return source;
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env)
+            throws IOException {
+        this.source.init(source, options, env);
+        lookahead.empty();
+        sourceEmpty = false;
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        source.seek(range, columnFamilies, inclusive);
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (sourceEmpty) {
+            return;
+        }
+        if (lookahead.isEmpty()) {
+            source.next();
+        }
+    }
+
+    @Override
+    public boolean hasTop() {
+        if (!lookahead.isEmpty()) {
+            return true;
+        }
+        if (sourceEmpty) {
+            return false;
+        }
+        boolean result = source.hasTop();
+        sourceEmpty = !result;
+        return result;
+    }
+
+    @Override
+    public Key getTopKey() {
+        if (!lookahead.isEmpty()) {
+            Key k = lookahead.getKey();
+            if (null == k) {
+                throw new IllegalStateException("Must call next to retrieve following key.");
+            }
+            lookahead.setKey(null);
+            return k;
+        }
+        return source.getTopKey();
+    }
+
+    @Override
+    public Value getTopValue() {
+        if (!lookahead.isEmpty()) {
+            Value v = lookahead.getValue();
+            if (null == v) {
+                throw new IllegalStateException("Must call next to retrieve following value.");
+            }
+            lookahead.setValue(null);
+            return v;
+        }
+        return source.getTopValue();
+    }
+
+    public KeyValuePair peek() throws IOException {
+        lookahead();
+        return sourceEmpty ? null : lookahead;
+    }
+
+    private void lookahead() throws IOException {
+        if (sourceEmpty || !lookahead.isEmpty()) {
+            return;
+        }
+        source.next();
+        if (source.hasTop()) {
+            this.lookahead.setKey(source.getTopKey());
+            this.lookahead.setValue(source.getTopValue());
+        } else {
+            this.sourceEmpty = true;
+            this.lookahead.empty();
+        }
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/server/src/main/java/timely/store/iterators/TimeWindowCombiner.java
+++ b/server/src/main/java/timely/store/iterators/TimeWindowCombiner.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package timely.store.iterators;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.IteratorSetting.Column;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.conf.ColumnSet;
+import org.apache.accumulo.core.util.ComparablePair;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import timely.api.model.Metric;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+
+/**
+ * This is a copy of org.apache.accumulo.core.iterators.Combiner with changes.
+ * The Combiner class will reduce all values with matching row, colf, colq, and
+ * colviz into one value. This iterator will reduce all values with matching
+ * row, colf, colq, and colviz into multiple K,V pairs based on the configured
+ * time window. The returned Key will be the first key in the time window.
+ * Additionally, the reduce method signature has changed to allow the passing of
+ * the Key and Value that are being reduced.
+ * 
+ */
+public abstract class TimeWindowCombiner implements SortedKeyValueIterator<Key, Value>, OptionDescriber {
+
+    /**
+     * A Java Iterator that returns a Key and Value when the given Key is within
+     * the time window.
+     */
+    public static class TimeWindowValueIterator implements Iterator<KeyValuePair> {
+
+        private final Key startKey;
+        private final LookaheadIterator source;
+        private final String startMetric;
+        private final byte[] startColf;
+        private final byte[] startColq;
+        private boolean hasNext;
+        private long window;
+
+        public TimeWindowValueIterator(LookaheadIterator source, long window) throws IOException {
+            this.source = source;
+            startKey = new Key(source.getTopKey());
+            ComparablePair<String, Long> row = Metric.decodeRowKey(startKey.getRow().getBytes());
+            this.startMetric = row.getFirst();
+            this.startColf = startKey.getColumnFamily().getBytes();
+            this.startColq = startKey.getColumnQualifier().getBytes();
+            this.window = window;
+            hasNext = isInWindow(startKey);
+        }
+
+        /**
+         * Test whether the given key is in the time window compared to the
+         * start key
+         * 
+         * @param test
+         *            key
+         * @return
+         */
+        private boolean isInWindow(Key test) {
+            if (!test.isDeleted() && (test.getTimestamp() - this.startKey.getTimestamp()) < this.window) {
+                ComparablePair<String, Long> row = Metric.decodeRowKey(test.getRow().getBytes());
+                return (startMetric.equals(row.getFirst())
+                        && Arrays.equals(startColf, test.getColumnFamily().getBytes()) && Arrays.equals(startColq, test
+                        .getColumnQualifier().getBytes()));
+            }
+            return false;
+        }
+
+        public boolean hasNext() {
+            return hasNext;
+        }
+
+        public KeyValuePair next() {
+            if (!hasNext)
+                throw new NoSuchElementException();
+            // Populate the response
+            KeyValuePair result = new KeyValuePair();
+            result.setKey(source.getTopKey());
+            result.setValue(source.getTopValue());
+            // Lookahead at the next key and test it
+            try {
+                KeyValuePair lookahead = source.peek();
+                if (null != lookahead) {
+                    if (isInWindow(lookahead.getKey())) {
+                        hasNext = true;
+                        source.next();
+                    } else {
+                        hasNext = false;
+                    }
+                } else {
+                    hasNext = false;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return result;
+        }
+
+        /**
+         * This method is unsupported in this iterator.
+         *
+         * @throws UnsupportedOperationException
+         *             when called
+         */
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    static final Logger sawDeleteLog = LoggerFactory.getLogger(TimeWindowCombiner.class.getName() + ".SawDelete");
+
+    protected static final String COLUMNS_OPTION = "columns";
+    protected static final String ALL_OPTION = "all";
+    protected static final String REDUCE_ON_FULL_COMPACTION_ONLY_OPTION = "reduceOnFullCompactionOnly";
+    protected static final String WINDOW_SIZE = "window.size";
+    @VisibleForTesting
+    static final Cache<String, Boolean> loggedMsgCache = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS)
+            .maximumSize(10000).build();
+
+    private LookaheadIterator source = null;
+    private boolean isMajorCompaction;
+    private boolean reduceOnFullCompactionOnly;
+    private Key topKey;
+    private Value topValue;
+    private Key workKey = new Key();
+    private ColumnSet combiners;
+    private boolean combineAllColumns;
+    private long window = -1L;
+
+    public void setSource(SortedKeyValueIterator<Key, Value> source) {
+        this.source = new LookaheadIterator(source);
+    }
+
+    @Override
+    public Key getTopKey() {
+        return topKey;
+    }
+
+    @Override
+    public Value getTopValue() {
+        return topValue;
+    }
+
+    @Override
+    public boolean hasTop() {
+        return (null != topKey && null != topValue);
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (topKey != null) {
+            topKey = null;
+            topValue = null;
+        }
+        source.next();
+
+        findTop();
+    }
+
+    private void sawDelete() {
+        if (isMajorCompaction && !reduceOnFullCompactionOnly) {
+            try {
+                loggedMsgCache.get(this.getClass().getName(), new Callable<Boolean>() {
+
+                    @Override
+                    public Boolean call() throws Exception {
+                        sawDeleteLog
+                                .error("Combiner of type {} saw a delete during a partial compaction.  This could cause undesired results.  See ACCUMULO-2232.  Will not log subsequent "
+                                        + "occurences for at least 1 hour.", this.getClass().getSimpleName());
+                        // the value is not used and does not matter
+                        return Boolean.TRUE;
+                    }
+                });
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Sets the topKey and topValue based on the top key of the source. If the
+     * column of the source top key is in the set of combiners, topKey will be
+     * the top key of the source and topValue will be the result of the reduce
+     * method. Otherwise, topKey and topValue will be unchanged. (They are
+     * always set to null before this method is called.)
+     */
+    private void findTop() throws IOException {
+        // check if aggregation is needed
+        if (source.hasTop()) {
+            workKey.set(source.getTopKey());
+            source.getTopValue(); // Have to eat the value in case we called
+                                  // peek in the TimeWindowValueIterator
+            if (combineAllColumns || combiners.contains(workKey)) {
+                if (workKey.isDeleted()) {
+                    sawDelete();
+                    return;
+                }
+                topKey = workKey;
+                Iterator<KeyValuePair> viter = new TimeWindowValueIterator(source, this.window);
+                topValue = reduce(topKey, viter);
+                // Consume the rest of the keys
+                while (viter.hasNext()) {
+                    viter.next();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        // do not want to seek to the middle of a value that should be
+        // combined...
+        Range seekRange = IteratorUtil.maximizeStartKeyTimeStamp(range);
+
+        source.seek(seekRange, columnFamilies, inclusive);
+        findTop();
+
+        if (range.getStartKey() != null) {
+            while (hasTop() && getTopKey().equals(range.getStartKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)
+                    && getTopKey().getTimestamp() > range.getStartKey().getTimestamp()) {
+                next();
+            }
+
+            while (hasTop() && range.beforeStartKey(getTopKey())) {
+                next();
+            }
+        }
+    }
+
+    /**
+     * Reduces a list of Values into a single Value.
+     *
+     * @param key
+     *            The most recent version of the Key being reduced.
+     *
+     * @param iter
+     *            An iterator over the Values for different versions of the key.
+     *
+     * @return The combined Value.
+     */
+    public abstract Value reduce(Key key, Iterator<KeyValuePair> iter);
+
+    @Override
+    public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env)
+            throws IOException {
+        this.source = new LookaheadIterator(source);
+
+        if (!options.containsKey(WINDOW_SIZE)) {
+            throw new IllegalArgumentException("options must include " + WINDOW_SIZE);
+        }
+        this.window = AccumuloConfiguration.getTimeInMillis(options.get(WINDOW_SIZE));
+
+        combineAllColumns = false;
+        if (options.containsKey(ALL_OPTION)) {
+            combineAllColumns = Boolean.parseBoolean(options.get(ALL_OPTION));
+            if (combineAllColumns)
+                return;
+        }
+
+        if (!options.containsKey(COLUMNS_OPTION))
+            throw new IllegalArgumentException("Must specify " + COLUMNS_OPTION + " option");
+
+        String encodedColumns = options.get(COLUMNS_OPTION);
+        if (encodedColumns.length() == 0)
+            throw new IllegalArgumentException("The " + COLUMNS_OPTION + " must not be empty");
+
+        combiners = new ColumnSet(Lists.newArrayList(Splitter.on(",").split(encodedColumns)));
+
+        isMajorCompaction = env.getIteratorScope() == IteratorScope.majc;
+
+        String rofco = options.get(REDUCE_ON_FULL_COMPACTION_ONLY_OPTION);
+        if (rofco != null) {
+            reduceOnFullCompactionOnly = Boolean.parseBoolean(rofco);
+        } else {
+            reduceOnFullCompactionOnly = false;
+        }
+
+        if (reduceOnFullCompactionOnly && isMajorCompaction && !env.isFullMajorCompaction()) {
+            // adjust configuration so that no columns are combined for a
+            // partial major compaction
+            combineAllColumns = false;
+            combiners = new ColumnSet();
+        }
+
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env) {
+        TimeWindowCombiner newInstance;
+        try {
+            newInstance = this.getClass().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        newInstance.setSource(source.getSource().deepCopy(env));
+        newInstance.combiners = combiners;
+        newInstance.combineAllColumns = combineAllColumns;
+        newInstance.isMajorCompaction = isMajorCompaction;
+        newInstance.reduceOnFullCompactionOnly = reduceOnFullCompactionOnly;
+        newInstance.window = this.window;
+        return newInstance;
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions io = new IteratorOptions("comb",
+                "Combiners apply reduce functions to multiple versions of values with otherwise equal keys", null, null);
+        io.addNamedOption(ALL_OPTION, "set to true to apply Combiner to every column, otherwise leave blank. if true, "
+                + COLUMNS_OPTION + " option will be ignored.");
+        io.addNamedOption(COLUMNS_OPTION,
+                "<col fam>[:<col qual>]{,<col fam>[:<col qual>]} escape non-alphanum chars using %<hex>.");
+        io.addNamedOption(REDUCE_ON_FULL_COMPACTION_ONLY_OPTION,
+                "If true, only reduce on full major compactions.  Defaults to false. ");
+        io.addNamedOption(WINDOW_SIZE, "Size (in time) of the window in which to combine values");
+        return io;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String, String> options) {
+        if (options.containsKey(ALL_OPTION)) {
+            try {
+                combineAllColumns = Boolean.parseBoolean(options.get(ALL_OPTION));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("bad boolean " + ALL_OPTION + ":" + options.get(ALL_OPTION));
+            }
+            if (combineAllColumns)
+                return true;
+        }
+        if (!options.containsKey(COLUMNS_OPTION))
+            throw new IllegalArgumentException("options must include " + ALL_OPTION + " or " + COLUMNS_OPTION);
+
+        String encodedColumns = options.get(COLUMNS_OPTION);
+        if (encodedColumns.length() == 0)
+            throw new IllegalArgumentException("empty columns specified in option " + COLUMNS_OPTION);
+
+        for (String columns : Splitter.on(",").split(encodedColumns)) {
+            if (!ColumnSet.isValidEncoding(columns))
+                throw new IllegalArgumentException("invalid column encoding " + encodedColumns);
+        }
+
+        if (!options.containsKey(WINDOW_SIZE)) {
+            throw new IllegalArgumentException("options must include " + WINDOW_SIZE);
+        }
+        return true;
+    }
+
+    /**
+     * A convenience method to set which columns a combiner should be applied
+     * to. For each column specified, all versions of a Key which match that
+     * 
+     * @{link IteratorSetting.Column} will be combined individually in each row.
+     *        This method is likely to be used in conjunction with
+     *        {@link ScannerBase#fetchColumnFamily(Text)} or
+     *        {@link ScannerBase#fetchColumn(Text,Text)}.
+     *
+     * @param is
+     *            iterator settings object to configure
+     * @param columns
+     *            a list of columns to encode as the value for the combiner
+     *            column configuration
+     */
+    public static void setColumns(IteratorSetting is, List<IteratorSetting.Column> columns) {
+        String sep = "";
+        StringBuilder sb = new StringBuilder();
+
+        for (Column col : columns) {
+            sb.append(sep);
+            sep = ",";
+            sb.append(ColumnSet.encodeColumns(col.getFirst(), col.getSecond()));
+        }
+
+        is.addOption(COLUMNS_OPTION, sb.toString());
+    }
+
+    /**
+     * A convenience method to set the "all columns" option on a Combiner. This
+     * will combine all columns individually within each row.
+     *
+     * @param is
+     *            iterator settings object to configure
+     * @param combineAllColumns
+     *            if true, the columns option is ignored and the Combiner will
+     *            be applied to all columns
+     */
+    public static void setCombineAllColumns(IteratorSetting is, boolean combineAllColumns) {
+        is.addOption(ALL_OPTION, Boolean.toString(combineAllColumns));
+    }
+
+    /**
+     * Combiners may not work correctly with deletes. Sometimes when Accumulo
+     * compacts the files in a tablet, it only compacts a subset of the files.
+     * If a delete marker exists in one of the files that is not being
+     * compacted, then data that should be deleted may be combined. See <a
+     * href="https://issues.apache.org/jira/browse/ACCUMULO-2232"
+     * >ACCUMULO-2232</a> for more information. For correctness deletes should
+     * not be used with columns that are combined OR this option should be set
+     * to true.
+     *
+     * <p>
+     * When this method is set to true all data is passed through during partial
+     * major compactions and no reducing is done. Reducing is only done during
+     * scan and full major compactions, when deletes can be correctly handled.
+     * Only reducing on full major compactions may have negative performance
+     * implications, leaving lots of work to be done at scan time.
+     *
+     * <p>
+     * When this method is set to false, combiners will log an error if a delete
+     * is seen during any compaction. This can be suppressed by adjusting
+     * logging configuration. Errors will not be logged more than once an hour
+     * per Combiner, regardless of how many deletes are seen.
+     *
+     * <p>
+     * This method was added in 1.6.4 and 1.7.1. If you want your code to work
+     * in earlier versions of 1.6 and 1.7 then do not call this method. If not
+     * set this property defaults to false in order to maintain compatibility.
+     *
+     * @since 1.6.5 1.7.1 1.8.0
+     */
+
+    public static void setReduceOnFullCompactionOnly(IteratorSetting is, boolean reduceOnFullCompactionOnly) {
+        is.addOption(REDUCE_ON_FULL_COMPACTION_ONLY_OPTION, Boolean.toString(reduceOnFullCompactionOnly));
+    }
+
+}

--- a/server/src/main/java/timely/store/iterators/WritableKey.java
+++ b/server/src/main/java/timely/store/iterators/WritableKey.java
@@ -1,0 +1,14 @@
+package timely.store.iterators;
+
+import org.apache.accumulo.core.data.Key;
+
+public class WritableKey extends Key {
+
+    public WritableKey(Key k) {
+        super(k);
+    }
+
+    public void setRow(byte[] r) {
+        this.row = r;
+    }
+}

--- a/server/src/test/java/timely/api/model/MetricTest.java
+++ b/server/src/test/java/timely/api/model/MetricTest.java
@@ -1,9 +1,9 @@
 package timely.api.model;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.accumulo.core.client.lexicoder.DoubleLexicoder;
 import org.apache.accumulo.core.client.lexicoder.LongLexicoder;
 import org.apache.accumulo.core.client.lexicoder.PairLexicoder;
 import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
@@ -40,9 +40,9 @@ public class MetricTest {
         Mutation mut = m.toMutation();
 
         PairLexicoder<String, Long> rowCoder = new PairLexicoder<>(new StringLexicoder(), new LongLexicoder());
-        DoubleLexicoder valueCoder = new DoubleLexicoder();
         byte[] row = rowCoder.encode(new ComparablePair<String, Long>("sys.cpu.user", ts));
-        byte[] value = valueCoder.encode(2.0D);
+        ByteBuffer bb = ByteBuffer.allocate(Double.BYTES);
+        bb.putDouble(2.0D);
         Assert.assertEquals(rowCoder.decode(row), rowCoder.decode(mut.getRow()));
         Assert.assertEquals(3, mut.getUpdates().size());
         ColumnUpdate up = mut.getUpdates().get(0);
@@ -50,19 +50,19 @@ public class MetricTest {
         Assert.assertTrue(new String(up.getColumnQualifier()).equals("tag2=value2,tag3=value3"));
         Assert.assertEquals(ts, up.getTimestamp());
         Assert.assertTrue(new String(up.getColumnVisibility()).equals(""));
-        Assert.assertEquals(valueCoder.decode(value), valueCoder.decode(up.getValue()));
+        Assert.assertArrayEquals(bb.array(), up.getValue());
         ColumnUpdate up2 = mut.getUpdates().get(1);
         Assert.assertTrue(new String(up2.getColumnFamily()).equals("tag2=value2"));
         Assert.assertTrue(new String(up2.getColumnQualifier()).equals("tag1=value1,tag3=value3"));
         Assert.assertEquals(ts, up2.getTimestamp());
         Assert.assertTrue(new String(up2.getColumnVisibility()).equals(""));
-        Assert.assertEquals(valueCoder.decode(value), valueCoder.decode(up2.getValue()));
+        Assert.assertArrayEquals(bb.array(), up2.getValue());
         ColumnUpdate up3 = mut.getUpdates().get(2);
         Assert.assertTrue(new String(up3.getColumnFamily()).equals("tag3=value3"));
         Assert.assertTrue(new String(up3.getColumnQualifier()).equals("tag1=value1,tag2=value2"));
         Assert.assertEquals(ts, up3.getTimestamp());
         Assert.assertTrue(new String(up3.getColumnVisibility()).equals(""));
-        Assert.assertEquals(valueCoder.decode(value), valueCoder.decode(up3.getValue()));
+        Assert.assertArrayEquals(bb.array(), up3.getValue());
     }
 
     @Test
@@ -79,9 +79,9 @@ public class MetricTest {
         Mutation mut = m.toMutation();
 
         PairLexicoder<String, Long> rowCoder = new PairLexicoder<>(new StringLexicoder(), new LongLexicoder());
-        DoubleLexicoder valueCoder = new DoubleLexicoder();
         byte[] row = rowCoder.encode(new ComparablePair<String, Long>("sys.cpu.user", ts));
-        byte[] value = valueCoder.encode(2.0D);
+        ByteBuffer bb = ByteBuffer.allocate(Double.BYTES);
+        bb.putDouble(2.0D);
         Assert.assertEquals(rowCoder.decode(row), rowCoder.decode(mut.getRow()));
         Assert.assertEquals(1, mut.getUpdates().size());
         ColumnUpdate up = mut.getUpdates().get(0);
@@ -89,7 +89,7 @@ public class MetricTest {
         Assert.assertEquals("", new String(up.getColumnQualifier()));
         Assert.assertEquals(ts, up.getTimestamp());
         Assert.assertEquals("(a&b)|(c&d)", new String(up.getColumnVisibility()));
-        Assert.assertEquals(valueCoder.decode(value), valueCoder.decode(up.getValue()));
+        Assert.assertArrayEquals(bb.array(), up.getValue());
     }
 
     @Test

--- a/server/src/test/java/timely/store/iterators/DataPointsCompactionIteratorTest.java
+++ b/server/src/test/java/timely/store/iterators/DataPointsCompactionIteratorTest.java
@@ -1,0 +1,74 @@
+package timely.store.iterators;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import timely.api.model.Metric;
+
+public class DataPointsCompactionIteratorTest extends IteratorTestBase {
+
+    private final ByteBuffer scratch = ByteBuffer.allocate(Double.BYTES);
+
+    @Test
+    public void testCompactSingle() throws Exception {
+
+        ByteBuffer expected = ByteBuffer.allocate(1000 * DataPointsExpansionIterator.TIME_VALUE_LENGTH);
+        /*
+         * Create a table and populate it with 1000 rows, 1 second apart
+         */
+        TreeMap<Key, Value> table = new TreeMap<>();
+        long timestamp = System.currentTimeMillis();
+        final String metric = "sys.cpu.user";
+        final byte[] colf = "host=r01n01".getBytes(StandardCharsets.UTF_8);
+        final byte[] colq = "rack=r01".getBytes(StandardCharsets.UTF_8);
+        final byte[] viz = new byte[0];
+
+        for (double i = 0; i < 1000; i++) {
+            scratch.clear();
+            scratch.putDouble(i);
+            timestamp += 1000;
+            byte[] row = Metric.encodeRowKey(metric, timestamp);
+            table.put(new Key(row, colf, colq, viz, timestamp), new Value(scratch.array()));
+        }
+        Assert.assertEquals(1000, table.size());
+
+        SortedMapIterator source = new SortedMapIterator(table);
+        source.seek(new Range(), EMPTY_COL_FAMS, false);
+        while (source.hasTop()) {
+            expected.putLong(source.getTopKey().getTimestamp());
+            expected.put(source.getTopValue().get());
+            source.next();
+        }
+
+        source = new SortedMapIterator(table);
+        DataPointsCompactionIterator iter = new DataPointsCompactionIterator();
+        IteratorSetting is = new IteratorSetting(1, DataPointsCompactionIterator.class);
+        is.addOption(TimeWindowCombiner.ALL_OPTION, "true");
+        is.addOption(TimeWindowCombiner.WINDOW_SIZE, "1d");
+        iter.init(source, is.getOptions(), SCAN_IE);
+        iter.seek(new Range(), EMPTY_COL_FAMS, false);
+
+        Assert.assertTrue(iter.hasTop());
+        Key topKey = iter.getTopKey();
+        Assert.assertNotNull(topKey);
+        Value topValue = iter.getTopValue();
+        Assert.assertNotNull(topValue);
+        Assert.assertArrayEquals(expected.array(), topValue.get());
+        iter.next();
+        Assert.assertFalse(iter.hasTop());
+
+    }
+
+    // TODO: Test compaction of many values
+
+    // TODO: Test compaction of mixed values
+}

--- a/server/src/test/java/timely/store/iterators/DataPointsExpansionIteratorTest.java
+++ b/server/src/test/java/timely/store/iterators/DataPointsExpansionIteratorTest.java
@@ -1,0 +1,106 @@
+package timely.store.iterators;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import timely.api.model.Metric;
+
+public class DataPointsExpansionIteratorTest extends IteratorTestBase {
+
+    @Test
+    public void testExpansionSingleValue() throws Exception {
+
+        // Create new Key/Value with a single value
+        long timestamp = System.currentTimeMillis();
+        final String metric = "sys.cpu.user";
+        final byte[] colf = "host=r01n01".getBytes(StandardCharsets.UTF_8);
+        final byte[] colq = "rack=r01".getBytes(StandardCharsets.UTF_8);
+        final byte[] viz = new byte[0];
+        byte[] row = Metric.encodeRowKey(metric, timestamp);
+        // Create a byte array with one Double
+        ByteBuffer b = ByteBuffer.allocate(Double.BYTES);
+        b.putDouble(5.0D);
+        Key k = new Key(row, colf, colq, viz, timestamp);
+        Value v = new Value(b.array());
+
+        TreeMap<Key, Value> table = new TreeMap<>();
+        table.put(k, v);
+
+        SortedMapIterator source = new SortedMapIterator(table);
+        DataPointsExpansionIterator iter = new DataPointsExpansionIterator();
+        iter.init(source, Collections.emptyMap(), SCAN_IE);
+        iter.seek(new Range(), EMPTY_COL_FAMS, false);
+
+        Assert.assertTrue(iter.hasTop());
+        Assert.assertEquals(k, iter.getTopKey());
+        Assert.assertEquals(b.array(), iter.getTopValue().get());
+        iter.next();
+        Assert.assertFalse(iter.hasTop());
+    }
+
+    @Test
+    public void testExpansionMany() throws Exception {
+
+        int iterations = 1000;
+        final ByteBuffer scratch = ByteBuffer.allocate(iterations * (Long.BYTES + Double.BYTES));
+
+        Map<Key, Double> expected = new TreeMap<>();
+
+        // Construct a Value with 1000 datapoints.
+        long timestamp = System.currentTimeMillis();
+        long startTimestamp = timestamp;
+        final String metric = "sys.cpu.user";
+        byte[] startRow = Metric.encodeRowKey(metric, timestamp);
+        final byte[] colf = "host=r01n01".getBytes(StandardCharsets.UTF_8);
+        final byte[] colq = "rack=r01".getBytes(StandardCharsets.UTF_8);
+        final byte[] viz = new byte[0];
+
+        for (double i = 0; i < iterations; i++) {
+            scratch.putLong(timestamp);
+            scratch.putDouble(i);
+            byte[] row = Metric.encodeRowKey(metric, timestamp);
+            expected.put(new Key(row, colf, colq, viz, timestamp), i);
+            timestamp += 1000;
+        }
+
+        // Put one K,V into table with 1000 serialized data points
+        TreeMap<Key, Value> table = new TreeMap<>();
+        table.put(new Key(startRow, colf, colq, viz, startTimestamp), new Value(scratch.array()));
+        Assert.assertEquals(1, table.size());
+
+        SortedMapIterator source = new SortedMapIterator(table);
+        DataPointsExpansionIterator iter = new DataPointsExpansionIterator();
+        iter.init(source, Collections.emptyMap(), SCAN_IE);
+        iter.seek(new Range(), EMPTY_COL_FAMS, false);
+
+        ByteBuffer b = ByteBuffer.allocate(Double.BYTES);
+        for (int i = 0; i < iterations; i++) {
+            Assert.assertTrue(iter.hasTop());
+            Assert.assertNotNull(iter.getTopKey());
+            Assert.assertNotNull(iter.getTopValue().get());
+            Assert.assertTrue(expected.containsKey(iter.getTopKey()));
+            b.clear();
+            b.put(iter.getTopValue().get());
+            b.position(0);
+            Assert.assertEquals(expected.get(iter.getTopKey()), b.getDouble(), 0.0D);
+            iter.next();
+        }
+        Assert.assertFalse(iter.hasTop());
+
+    }
+
+    // TODO: Test Expansion of mixed and single values
+
+    // TODO: Add test where data points are not in time order and range end is
+    // in the middle of the values.
+}

--- a/server/src/test/java/timely/store/iterators/IteratorTestBase.java
+++ b/server/src/test/java/timely/store/iterators/IteratorTestBase.java
@@ -1,0 +1,93 @@
+package timely.store.iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.system.MapFileIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.CachedConfiguration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+public class IteratorTestBase {
+
+    protected static class DefaultIteratorEnvironment implements IteratorEnvironment {
+
+        AccumuloConfiguration conf;
+
+        public DefaultIteratorEnvironment(AccumuloConfiguration conf) {
+            this.conf = conf;
+        }
+
+        public DefaultIteratorEnvironment() {
+            this.conf = AccumuloConfiguration.getDefaultConfiguration();
+        }
+
+        @Override
+        public SortedKeyValueIterator<Key, Value> reserveMapFileReader(String mapFileName) throws IOException {
+            Configuration conf = CachedConfiguration.getInstance();
+            FileSystem fs = FileSystem.get(conf);
+            return new MapFileIterator(this.conf, fs, mapFileName, conf);
+        }
+
+        @Override
+        public AccumuloConfiguration getConfig() {
+            return conf;
+        }
+
+        @Override
+        public IteratorScope getIteratorScope() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isFullMajorCompaction() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerSideChannel(SortedKeyValueIterator<Key, Value> iter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Authorizations getAuthorizations() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    protected static class CombinerIteratorEnvironment extends DefaultIteratorEnvironment {
+
+        private IteratorScope scope;
+        private boolean isFullMajc;
+
+        CombinerIteratorEnvironment(IteratorScope scope, boolean isFullMajc) {
+            this.scope = scope;
+            this.isFullMajc = isFullMajc;
+        }
+
+        @Override
+        public IteratorScope getIteratorScope() {
+            return scope;
+        }
+
+        @Override
+        public boolean isFullMajorCompaction() {
+            return isFullMajc;
+        }
+    }
+
+    protected static final IteratorEnvironment SCAN_IE = new CombinerIteratorEnvironment(IteratorScope.scan, false);
+
+    protected static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<ByteSequence>();
+
+}

--- a/server/src/test/java/timely/store/iterators/LookaheadIteratorTest.java
+++ b/server/src/test/java/timely/store/iterators/LookaheadIteratorTest.java
@@ -1,0 +1,116 @@
+package timely.store.iterators;
+
+import java.nio.charset.StandardCharsets;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import timely.api.model.Metric;
+
+public class LookaheadIteratorTest extends IteratorTestBase {
+
+    @Test
+    public void testLookaheadIterator() throws Exception {
+
+        /*
+         * Create a table and insert 10 rows each 1 second apart
+         */
+        TreeMap<Key, Value> table = new TreeMap<>();
+        Value emptyValue = new Value(new byte[0]);
+        long timestamp = System.currentTimeMillis();
+        final String metric = "sys.cpu.user";
+        final byte[] colf = "host=r01n01".getBytes(StandardCharsets.UTF_8);
+        final byte[] colq = "rack=r01".getBytes(StandardCharsets.UTF_8);
+        final byte[] viz = new byte[0];
+
+        for (long i = 0; i < 10; i++) {
+            timestamp += 1000;
+            byte[] row = Metric.encodeRowKey(metric, timestamp);
+            table.put(new Key(row, colf, colq, viz, timestamp), emptyValue);
+        }
+
+        /*
+         * Build a set of expected keys in the correct order
+         */
+        Assert.assertEquals(10, table.size());
+        Key[] expected = new Key[10];
+        int i = 0;
+        SortedMapIterator s = new SortedMapIterator(table);
+        s.seek(new Range(), EMPTY_COL_FAMS, false);
+        while (s.hasTop()) {
+            expected[i] = s.getTopKey();
+            s.next();
+            i++;
+        }
+
+        /*
+         * Iterate over the table, peeking and calling next
+         */
+        SortedMapIterator source = new SortedMapIterator(table);
+        LookaheadIterator l = new LookaheadIterator(source);
+        l.seek(new Range(), EMPTY_COL_FAMS, false);
+
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[0].getTimestamp(), l.getTopKey().getTimestamp());
+
+        // Lookahead at the next value
+        KeyValuePair lookahead = l.peek();
+        Assert.assertEquals(expected[1].getTimestamp(), lookahead.getKey().getTimestamp());
+
+        // Move ahead to the next value, which is really the last value because
+        // of the peek.
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[1].getTimestamp(), l.getTopKey().getTimestamp());
+        l.getTopValue(); // must call getTopKey and getTopValue after a peek to
+                         // clear the internal state
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[2].getTimestamp(), l.getTopKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[3].getTimestamp(), l.getTopKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[4].getTimestamp(), l.getTopKey().getTimestamp());
+
+        lookahead = l.peek();
+        Assert.assertEquals(expected[5].getTimestamp(), lookahead.getKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[5].getTimestamp(), l.getTopKey().getTimestamp());
+        l.getTopValue(); // must call getTopKey and getTopValue after a peek to
+                         // clear the internal state
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[6].getTimestamp(), l.getTopKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[7].getTimestamp(), l.getTopKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[8].getTimestamp(), l.getTopKey().getTimestamp());
+
+        l.next();
+        Assert.assertTrue(l.hasTop());
+        Assert.assertEquals(expected[9].getTimestamp(), l.getTopKey().getTimestamp());
+
+        Assert.assertNull(l.peek());
+        l.next();
+        Assert.assertFalse(l.hasTop());
+        Assert.assertNull(l.peek());
+
+    }
+}

--- a/server/src/test/java/timely/store/iterators/TimeWindowCombinerTest.java
+++ b/server/src/test/java/timely/store/iterators/TimeWindowCombinerTest.java
@@ -1,0 +1,125 @@
+package timely.store.iterators;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import timely.api.model.Metric;
+
+public class TimeWindowCombinerTest extends IteratorTestBase {
+
+    public static class SummingLongTimeCombiner extends TimeWindowCombiner {
+
+        @Override
+        public Value reduce(Key key, Iterator<KeyValuePair> iter) {
+            final ByteBuffer scratch = ByteBuffer.allocate(Long.BYTES);
+            long result = 0L;
+            while (iter.hasNext()) {
+                KeyValuePair kvp = iter.next();
+                Value v = kvp.getValue();
+                scratch.clear();
+                scratch.put(v.get());
+                scratch.position(0);
+                result += scratch.getLong();
+            }
+            scratch.clear();
+            scratch.putLong(result);
+            return new Value(scratch.array());
+        }
+    }
+
+    private final ByteBuffer scratch = ByteBuffer.allocate(Long.BYTES);
+
+    @Test
+    public void testTimeWindow() throws Exception {
+
+        /*
+         * Create a table and populate it with 1000 rows, 1 second apart
+         */
+        TreeMap<Key, Value> table = new TreeMap<>();
+        long timestamp = System.currentTimeMillis();
+        final String metric = "sys.cpu.user";
+        final byte[] colf = "host=r01n01".getBytes(StandardCharsets.UTF_8);
+        final byte[] colq = "rack=r01".getBytes(StandardCharsets.UTF_8);
+        final byte[] viz = new byte[0];
+
+        for (long i = 0; i < 1000; i++) {
+            scratch.clear();
+            scratch.putLong(i);
+            timestamp += 1000;
+            byte[] row = Metric.encodeRowKey(metric, timestamp);
+            table.put(new Key(row, colf, colq, viz, timestamp), new Value(scratch.array()));
+        }
+        Assert.assertEquals(1000, table.size());
+
+        /*
+         * Create the expected set of results by summing the value every 10 rows
+         */
+        Map<Key, Value> expected = new TreeMap<>();
+        int i = 0;
+        Key start = null;
+        Long aggregate = 0L;
+        SortedMapIterator s = new SortedMapIterator(table);
+        s.seek(new Range(), EMPTY_COL_FAMS, false);
+        while (s.hasTop()) {
+            if (null == start) {
+                start = s.getTopKey();
+            }
+            if ((i % 10) == 0) {
+                scratch.clear();
+                scratch.putLong(aggregate);
+                expected.put(start, new Value(scratch.array()));
+                aggregate = 0L;
+                start = s.getTopKey();
+            }
+            scratch.clear();
+            scratch.put(s.getTopValue().get());
+            scratch.position(0);
+            aggregate += scratch.getLong();
+            i++;
+            s.next();
+        }
+        scratch.clear();
+        scratch.putLong(aggregate);
+        expected.put(start, new Value(scratch.array()));
+        Assert.assertEquals("Expected size is not correct", 100, expected.size());
+
+        /*
+         * Set up a scan iterator that will sum the values in 10 seconds windows
+         */
+        SummingLongTimeCombiner c = new SummingLongTimeCombiner();
+        IteratorSetting is = new IteratorSetting(1, SummingLongTimeCombiner.class);
+        is.addOption(TimeWindowCombiner.ALL_OPTION, "true");
+        is.addOption(TimeWindowCombiner.WINDOW_SIZE, "10s");
+
+        c.validateOptions(is.getOptions());
+        c.init(new SortedMapIterator(table), is.getOptions(), SCAN_IE);
+        c.seek(new Range(), EMPTY_COL_FAMS, false);
+
+        Map<Key, Value> results = new TreeMap<>();
+        while (c.hasTop()) {
+            Key k = c.getTopKey();
+            Value v = c.getTopValue();
+            results.put((Key) k.clone(), new Value(v.get()));
+            c.next();
+        }
+        Assert.assertEquals("Sizes are not equal", expected.size(), results.size());
+        Assert.assertEquals(expected, results);
+        for (Entry<Key, Value> exp : expected.entrySet()) {
+            Value result = results.get(exp.getKey());
+            Assert.assertNotNull("result missing for key: " + exp.getKey(), result);
+        }
+    }
+
+}


### PR DESCRIPTION
DO NOT MERGE!!!

Work in progress, looking for feedback. I'm changing the way that metric values are stored in the metrics table. Currently the metric value, a java double, is stored in the Value of the Accumulo K/V pair serialized using a DoubleLexicoder.

The changes to existing code are to remove the lexicoder (don't need to sort) and writing the bytes for the double into the Value. New items:

1. I created a LookaheadIterator that will allow one to peek at the next K/V pair to test it
2. Currently, the Accumulo Combiner class will aggregate all Values for matching R/CF/CQ/CV. I have created a TimeWindowCombiner that does the same, except that it passes the Key to the reduce function and it will allow the user to configure windows of time for aggregation. The Key for the reduced value is always the starting key of the time window. For example, aggregate all K/Vs that have the same R/CF/CQ/CV into 1 minute buckets. This uses the Lookahead iterator to test the next K/V pair.
3. Created a DataPointCompactionIterator that uses the TimeWindowCombiner to compact all metric table K/V pairs in the given time window such that the Value contains the bytes of the timestamp followed by the bytes of the metric value, repeating...
4. Create a DataPointExpansionIterator that expands the compacted data structure on query.