### PR TITLE
Update datasource.js for grafana 4

### DIFF
--- a/grafana/timely-app/dist/datasource/datasource.js
+++ b/grafana/timely-app/dist/datasource/datasource.js
@@ -493,7 +493,7 @@ System.register(['lodash', 'angular', '../../../app/core/utils/datemath'], funct
                 if (target.filters && target.filters.length > 0) {
                   return target.metric === metricData.metric;
                 } else {
-                  return target.metric === metricData.metric && _.all(target.tags, function (tagV, tagK) {
+                  return target.metric === metricData.metric && _.every(target.tags, function (tagV, tagK) {
                     interpolatedTagValue = this.templateSrv.replace(tagV, options.scopedVars, 'pipe');
                     return metricData.tags[tagK] === interpolatedTagValue || interpolatedTagValue === "*";
                   }.bind(this));


### PR DESCRIPTION
Update _.all to _.every as the newer version of lodash has changed the term. This fixes error seen with Timely Standalon and Grafana >4.2.

The .all alias was removed from the .every function call in lodash > version 4. .every has existed since lodash 0.1.0 and is functionally equivalent, so this change is backward compatible and safe. https://lodash.com/docs/3.10.1#every