### PR TITLE
Minor fix-ups to default configuration files.

### DIFF
--- a/server/conf/timely-docker.yml
+++ b/server/conf/timely-docker.yml
@@ -19,7 +19,7 @@ timely:
   security:
     session-max-age: 86400
     allow-anonymous-access: true
-    ssl:
+    server-ssl:
       certificate-file: /timely-server-src/server/pki/timely.csr
       key-file: /timely-server-src/server/pki/timely-pkcs8.key
       key-password: password

--- a/server/conf/timely-standalone.yml
+++ b/server/conf/timely-standalone.yml
@@ -3,6 +3,8 @@ timely:
   meta-table: timely.meta
   metric-age-off-days:
     default: 7
+  cache:
+    enabled: false
   metrics-report-ignored-tags:
   accumulo:
     instance-name: TimelyStandalone
@@ -19,7 +21,7 @@ timely:
   security:
     session-max-age: 86400
     allow-anonymous-access: true
-    ssl:
+    server-ssl:
       certificate-file:
       key-file:
       key-password: timely

--- a/server/conf/timely.yml
+++ b/server/conf/timely.yml
@@ -23,7 +23,7 @@ timely:
   security:
     session-max-age: 86400
     allow-anonymous-access: true
-    serverSsl:
+    server-ssl:
       certificate-file:
       key-file:
       key-password:


### PR DESCRIPTION
  . Replace `ssl` with `server-ssl` in `timely-standalone.yml` and `timely-docker.yml`
  . Add a value for `cache.enabled` in `timely.yml`

(Was running timely-standalone per quick start documentation and discovered it wouldn't start)