### PR TITLE
Fix most compiler warnings and many other issues

### DIFF
--- a/analytics/src/main/java/timely/analytics/flink/SummarizationJob.java
+++ b/analytics/src/main/java/timely/analytics/flink/SummarizationJob.java
@@ -67,7 +67,7 @@ public class SummarizationJob {
         })
         .name("Metric Windows")
         .addSink(
-    		new SocketClientSink<MetricHistogram>(jp.getTimelyHostname(), jp.getTimelyTcpPort(),
+            new SocketClientSink<MetricHistogram>(jp.getTimelyHostname(), jp.getTimelyTcpPort(),
                     new MetricHistogram(), 2, true) {
 
                 private final Logger LOG = LoggerFactory

--- a/balancer/pom.xml
+++ b/balancer/pom.xml
@@ -162,7 +162,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${version.netty-tcnative}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/balancer/src/main/java/timely/balancer/Balancer.java
+++ b/balancer/src/main/java/timely/balancer/Balancer.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -450,10 +451,9 @@ public class Balancer {
         wsServer.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
         wsServer.option(ChannelOption.SO_BACKLOG, 128);
         wsServer.option(ChannelOption.SO_KEEPALIVE, true);
-        /* Not sure if next three lines are necessary */
+        /* Not sure if next two lines are necessary */
         wsServer.option(ChannelOption.SO_SNDBUF, 1048576);
-        wsServer.option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 838860);
-        wsServer.option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 620145);
+        wsServer.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(620145, 838860));
         wsChannelHandle = wsServer.bind(wsIp, wsPort).sync().channel();
         final String wsAddress = ((InetSocketAddress) wsChannelHandle.localAddress()).getAddress().getHostAddress();
 

--- a/balancer/src/main/java/timely/balancer/configuration/BalancerHttp.java
+++ b/balancer/src/main/java/timely/balancer/configuration/BalancerHttp.java
@@ -3,6 +3,7 @@ package timely.balancer.configuration;
 import javax.validation.Valid;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import timely.configuration.Http;
 
@@ -10,9 +11,9 @@ public class BalancerHttp extends Http {
 
     @Valid
     @NestedConfigurationProperty
-    private GenericKeyedObjectPoolConfig httpClientPool = new GenericKeyedObjectPoolConfig();
+    private GenericKeyedObjectPoolConfig<CloseableHttpClient> httpClientPool = new GenericKeyedObjectPoolConfig<>();
 
-    public GenericKeyedObjectPoolConfig getHttpClientPool() {
+    public GenericKeyedObjectPoolConfig<CloseableHttpClient> getHttpClientPool() {
         return httpClientPool;
     }
 }

--- a/balancer/src/main/java/timely/balancer/configuration/BalancerServer.java
+++ b/balancer/src/main/java/timely/balancer/configuration/BalancerServer.java
@@ -4,27 +4,29 @@ import javax.validation.Valid;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import timely.client.tcp.TcpClient;
+import timely.client.udp.UdpClient;
 import timely.configuration.Server;
 
 public class BalancerServer extends Server {
 
     @Valid
     @NestedConfigurationProperty
-    private GenericKeyedObjectPoolConfig udpClientPool = new GenericKeyedObjectPoolConfig();
+    private GenericKeyedObjectPoolConfig<UdpClient> udpClientPool = new GenericKeyedObjectPoolConfig<>();
 
     @Valid
     @NestedConfigurationProperty
-    private GenericKeyedObjectPoolConfig tcpClientPool = new GenericKeyedObjectPoolConfig();
+    private GenericKeyedObjectPoolConfig<TcpClient> tcpClientPool = new GenericKeyedObjectPoolConfig<>();
 
     private int numTcpPools = 1;
 
     private int tcpBufferSize = -1;
 
-    public GenericKeyedObjectPoolConfig getUdpClientPool() {
+    public GenericKeyedObjectPoolConfig<UdpClient> getUdpClientPool() {
         return udpClientPool;
     }
 
-    public GenericKeyedObjectPoolConfig getTcpClientPool() {
+    public GenericKeyedObjectPoolConfig<TcpClient> getTcpClientPool() {
         return tcpClientPool;
     }
 

--- a/balancer/src/main/java/timely/balancer/configuration/BalancerWebsocket.java
+++ b/balancer/src/main/java/timely/balancer/configuration/BalancerWebsocket.java
@@ -4,15 +4,16 @@ import javax.validation.Valid;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import timely.client.websocket.subscription.WebSocketSubscriptionClient;
 import timely.configuration.Websocket;
 
 public class BalancerWebsocket extends Websocket {
 
     @Valid
     @NestedConfigurationProperty
-    private GenericKeyedObjectPoolConfig wsClientPool = new GenericKeyedObjectPoolConfig();
+    private GenericKeyedObjectPoolConfig<WebSocketSubscriptionClient> wsClientPool = new GenericKeyedObjectPoolConfig<>();
 
-    public GenericKeyedObjectPoolConfig getWsClientPool() {
+    public GenericKeyedObjectPoolConfig<WebSocketSubscriptionClient> getWsClientPool() {
         return wsClientPool;
     }
 }

--- a/balancer/src/main/java/timely/balancer/connection/http/HttpClientPool.java
+++ b/balancer/src/main/java/timely/balancer/connection/http/HttpClientPool.java
@@ -4,15 +4,11 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import timely.balancer.configuration.BalancerHttp;
 import timely.balancer.configuration.BalancerSecurity;
 import timely.balancer.connection.TimelyBalancedHost;
 
 public class HttpClientPool extends GenericKeyedObjectPool<TimelyBalancedHost, CloseableHttpClient> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(HttpClientPool.class);
 
     public HttpClientPool(BalancerSecurity balancerSecurity, BalancerHttp http, SSLContext sslContext) {
         super(new HttpClientFactory(balancerSecurity, sslContext), http.getHttpClientPool());

--- a/balancer/src/main/java/timely/balancer/netty/http/HttpRelayHandler.java
+++ b/balancer/src/main/java/timely/balancer/netty/http/HttpRelayHandler.java
@@ -1,6 +1,6 @@
 package timely.balancer.netty.http;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URLEncoder;
@@ -67,7 +67,7 @@ public class HttpRelayHandler extends SimpleChannelInboundHandler<HttpRequest> i
         try {
             try {
                 request = msg.getHttpRequest();
-                String originalURI = request.getUri();
+                String originalURI = request.uri();
                 originalURI = encodeURI(originalURI);
 
                 String metric = null;
@@ -101,7 +101,7 @@ public class HttpRelayHandler extends SimpleChannelInboundHandler<HttpRequest> i
 
                 List<Header> relayedHeaderList = new ArrayList<>();
                 for (Map.Entry<String, String> h : headers.entries()) {
-                    if (!h.getKey().equals(CONTENT_LENGTH)) {
+                    if (!h.getKey().equals(CONTENT_LENGTH.toString())) {
                         relayedHeaderList.add(new BasicHeader(h.getKey(), h.getValue()));
                     }
                 }
@@ -109,14 +109,14 @@ public class HttpRelayHandler extends SimpleChannelInboundHandler<HttpRequest> i
                 relayedHeaderList.toArray(headerArray);
 
                 String relayURI = "https://" + k.getHost() + ":" + k.getHttpPort() + originalURI;
-                if (request.getMethod().equals(HttpMethod.GET)) {
+                if (request.method().equals(HttpMethod.GET)) {
                     HttpUriRequest relayedRequest = new HttpGet(relayURI);
                     if (headerArray.length > 0) {
                         relayedRequest.setHeaders(headerArray);
                     }
                     relayedResponse = client.execute(relayedRequest);
 
-                } else if (request.getMethod().equals(HttpMethod.POST)) {
+                } else if (request.method().equals(HttpMethod.POST)) {
                     HttpPost relayedRequest = new HttpPost(relayURI);
 
                     String content = request.content().toString(StandardCharsets.UTF_8);
@@ -170,7 +170,7 @@ public class HttpRelayHandler extends SimpleChannelInboundHandler<HttpRequest> i
             if (client != null && k != null) {
                 httpClientPool.returnObject(k, client);
             } else {
-                LOG.error("NOT RETURNING CONNECTION! " + msg.getHttpRequest().getUri());
+                LOG.error("NOT RETURNING CONNECTION! " + msg.getHttpRequest().uri());
             }
         }
     }

--- a/balancer/src/main/java/timely/balancer/netty/ws/WsClientHandler.java
+++ b/balancer/src/main/java/timely/balancer/netty/ws/WsClientHandler.java
@@ -45,7 +45,7 @@ public class WsClientHandler extends ClientHandler {
             Multimap<String, String> proxyRequestHeaders = HashMultimap.create();
             ProxiedEntityUtils.addProxyHeaders(proxyRequestHeaders, token.getClientCert());
             for (String s : proxyRequestHeaders.keySet()) {
-                headers.put(s, new ArrayList(proxyRequestHeaders.get(s)));
+                headers.put(s, new ArrayList<>(proxyRequestHeaders.get(s)));
             }
         }
 
@@ -53,7 +53,7 @@ public class WsClientHandler extends ClientHandler {
         for (String s : originalRequestHeaders.keySet()) {
             if (!headers.containsKey(s)) {
                 // add pre-existing values if key does not exist in proxyRequest
-                headers.put(s, new ArrayList(originalRequestHeaders.get(s)));
+                headers.put(s, new ArrayList<>(originalRequestHeaders.get(s)));
             }
         }
     }

--- a/client/src/main/java/timely/client/tcp/TcpClient.java
+++ b/client/src/main/java/timely/client/tcp/TcpClient.java
@@ -47,7 +47,6 @@ public class TcpClient implements AutoCloseable {
      * 
      * @param metric
      *            newline terminated string representation of Timely metric
-     * @throws IOException
      */
     public synchronized void write(String metric) throws IOException {
         if (connect() != 0) {

--- a/client/src/main/java/timely/model/ObjectSizeOf.java
+++ b/client/src/main/java/timely/model/ObjectSizeOf.java
@@ -62,7 +62,6 @@ public interface ObjectSizeOf {
          * ObjectSizeOf interface and if implemented on the object will use that.
          * Otherwise it will do a simple navigation of the fields using reflection.
          *
-         * @param o
          * @return an approximation of the object size
          */
         public static long getObjectSize(Object o, boolean useSizeInBytesMethod, boolean debug) {

--- a/client/src/main/java/timely/model/Tag.java
+++ b/client/src/main/java/timely/model/Tag.java
@@ -77,8 +77,6 @@ public class Tag implements Comparable<Tag>, Serializable {
 
     /**
      * Joins key and value into key=value
-     * 
-     * @return
      */
     public String join() {
         return tagParser.combine(this);

--- a/client/src/main/java/timely/model/parse/TagListParser.java
+++ b/client/src/main/java/timely/model/parse/TagListParser.java
@@ -47,7 +47,6 @@ public class TagListParser implements Parser<List<Tag>>, Combiner<Collection<Tag
      * An alternative combiner for a map of string to string instead of a list of
      * tags
      * 
-     * @param tags
      * @return string representation
      */
     public String combine(Map<String, String> tags) {

--- a/client/src/test/java/timely/api/SerializationTest.java
+++ b/client/src/test/java/timely/api/SerializationTest.java
@@ -47,9 +47,9 @@ public class SerializationTest {
         testSerialization(remove);
     }
 
-    @SuppressWarnings("unchecked")
     private <T> void testSerialization(T o) throws Exception {
         String ser = mapper.writeValueAsString(o);
+        @SuppressWarnings("unchecked")
         T des = mapper.readValue(ser, (Class<T>) o.getClass());
         Assert.assertEquals(o, des);
     }

--- a/collectd-nsq-plugin/src/main/java/timely/collectd/plugin/PooledCloseableHttpClientFactory.java
+++ b/collectd-nsq-plugin/src/main/java/timely/collectd/plugin/PooledCloseableHttpClientFactory.java
@@ -10,88 +10,89 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.collectd.api.OConfigItem;
 
-public class PooledCloseableHttpClientFactory implements PooledObjectFactory {
+public class PooledCloseableHttpClientFactory implements PooledObjectFactory<CloseableHttpClient> {
 
-    private int connectionRequestTimeout = 10000; // 10 seconds in milliseconds
-    private int connectTimeout = 30000; // 30 seconds in milliseconds
-    private int socketTimeout = 60000; // 60 seconds in milliseconds
-    private long connectionTimeToLive = 300000; // 300 seconds in milliseconds
+  private int connectionRequestTimeout = 10000; // 10 seconds in milliseconds
+  private int connectTimeout = 30000; // 30 seconds in milliseconds
+  private int socketTimeout = 60000; // 60 seconds in milliseconds
+  private long connectionTimeToLive = 300000; // 300 seconds in milliseconds
 
-    public int config(OConfigItem config) {
-        for (OConfigItem child : config.getChildren()) {
-            switch (child.getKey()) {
-                case "connectionRequestTimeout":
-                case "ConnectionRequestTimeout":
-                    connectionRequestTimeout = Integer.parseInt(child.getValues().get(0).getString());
-                    break;
-                case "connectTimeout":
-                case "ConnectTimeout":
-                    connectTimeout = Integer.parseInt(child.getValues().get(0).getString());
-                    break;
-                case "socketTimeout":
-                case "SocketTimeout":
-                    socketTimeout = Integer.parseInt(child.getValues().get(0).getString());
-                    break;
-                case "connectionTimeToLive":
-                case "ConnectionTimeToLive":
-                    connectionTimeToLive = Long.parseLong(child.getValues().get(0).getString());
-                    break;
-                default:
-            }
-        }
-        return 0;
+  public int config(OConfigItem config) {
+    for (OConfigItem child : config.getChildren()) {
+      switch (child.getKey()) {
+        case "connectionRequestTimeout":
+        case "ConnectionRequestTimeout":
+          connectionRequestTimeout = Integer.parseInt(child.getValues().get(0).getString());
+          break;
+        case "connectTimeout":
+        case "ConnectTimeout":
+          connectTimeout = Integer.parseInt(child.getValues().get(0).getString());
+          break;
+        case "socketTimeout":
+        case "SocketTimeout":
+          socketTimeout = Integer.parseInt(child.getValues().get(0).getString());
+          break;
+        case "connectionTimeToLive":
+        case "ConnectionTimeToLive":
+          connectionTimeToLive = Long.parseLong(child.getValues().get(0).getString());
+          break;
+        default:
+      }
     }
+    return 0;
+  }
 
-    @Override
-    public PooledObject makeObject() throws Exception {
-        RequestConfig requestConfig = RequestConfig.custom().setConnectionRequestTimeout(connectionRequestTimeout)
-                .setConnectTimeout(connectTimeout).setSocketTimeout(socketTimeout).build();
-        HttpClientBuilder builder = HttpClientBuilder.create();
-        builder.setDefaultRequestConfig(requestConfig);
-        builder.setConnectionTimeToLive(connectionTimeToLive, TimeUnit.MILLISECONDS);
-        return new DefaultPooledObject(builder.build());
-    }
+  @Override
+  public PooledObject<CloseableHttpClient> makeObject() throws Exception {
+    RequestConfig requestConfig =
+        RequestConfig.custom().setConnectionRequestTimeout(connectionRequestTimeout)
+            .setConnectTimeout(connectTimeout).setSocketTimeout(socketTimeout).build();
+    HttpClientBuilder builder = HttpClientBuilder.create();
+    builder.setDefaultRequestConfig(requestConfig);
+    builder.setConnectionTimeToLive(connectionTimeToLive, TimeUnit.MILLISECONDS);
+    return new DefaultPooledObject<>(builder.build());
+  }
 
-    @Override
-    public void destroyObject(PooledObject pooledObject) throws Exception {
-        try {
-            ((CloseableHttpClient) pooledObject.getObject()).close();
-        } catch (Exception e) {
-            // do nothing
-        } finally {
-            pooledObject.invalidate();
-            ;
-        }
+  @Override
+  public void destroyObject(PooledObject<CloseableHttpClient> pooledObject) throws Exception {
+    try {
+      pooledObject.getObject().close();
+    } catch (Exception e) {
+      // do nothing
+    } finally {
+      pooledObject.invalidate();
+      ;
     }
+  }
 
-    @Override
-    public boolean validateObject(PooledObject pooledObject) {
-        return pooledObject.getObject() != null;
-    }
+  @Override
+  public boolean validateObject(PooledObject<CloseableHttpClient> pooledObject) {
+    return pooledObject.getObject() != null;
+  }
 
-    @Override
-    public void activateObject(PooledObject pooledObject) throws Exception {
-        // do nothing
-    }
+  @Override
+  public void activateObject(PooledObject<CloseableHttpClient> pooledObject) throws Exception {
+    // do nothing
+  }
 
-    @Override
-    public void passivateObject(PooledObject pooledObject) throws Exception {
-        // do nothing
-    }
+  @Override
+  public void passivateObject(PooledObject<CloseableHttpClient> pooledObject) throws Exception {
+    // do nothing
+  }
 
-    public void setConnectionRequestTimeout(int connectionRequestTimeout) {
-        this.connectionRequestTimeout = connectionRequestTimeout;
-    }
+  public void setConnectionRequestTimeout(int connectionRequestTimeout) {
+    this.connectionRequestTimeout = connectionRequestTimeout;
+  }
 
-    public void setConnectTimeout(int connectTimeout) {
-        this.connectTimeout = connectTimeout;
-    }
+  public void setConnectTimeout(int connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
 
-    public void setSocketTimeout(int socketTimeout) {
-        this.socketTimeout = socketTimeout;
-    }
+  public void setSocketTimeout(int socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
 
-    public void setConnectionTimeToLive(long connectionTimeToLive) {
-        this.connectionTimeToLive = connectionTimeToLive;
-    }
+  public void setConnectionTimeToLive(long connectionTimeToLive) {
+    this.connectionTimeToLive = connectionTimeToLive;
+  }
 }

--- a/collectd-nsq-plugin/src/main/java/timely/collectd/plugin/WriteNSQPlugin.java
+++ b/collectd-nsq-plugin/src/main/java/timely/collectd/plugin/WriteNSQPlugin.java
@@ -23,142 +23,141 @@ import org.collectd.api.ValueList;
 
 /**
  *
- * CollectD plugin that writes metrics collected by the StatsD plugin to NSQ.
- * NSQ can be configured to write statsd metrics to CollectD. If you do this,
- * set the statsd prefix in NSQ to 'nsq'.
+ * CollectD plugin that writes metrics collected by the StatsD plugin to NSQ. NSQ can be configured
+ * to write statsd metrics to CollectD. If you do this, set the statsd prefix in NSQ to 'nsq'.
  *
  */
 public class WriteNSQPlugin extends CollectDPluginParent
-        implements CollectdConfigInterface, CollectdShutdownInterface, CollectdWriteInterface {
+    implements CollectdConfigInterface, CollectdShutdownInterface, CollectdWriteInterface {
 
-    private String host = null;
-    private int port = 0;
-    private String topic = "metrics#ephemeral";
-    private String endpoint = null;
-    private GenericObjectPool<CloseableHttpClient> clientPool = null;
+  private String host = null;
+  private int port = 0;
+  private String topic = "metrics#ephemeral";
+  private String endpoint = null;
+  private GenericObjectPool<CloseableHttpClient> clientPool = null;
 
-    // pool should be limited by the number of WriteThreads configured in
-    // collectd
-    final private int POOL_MAX_SIZE = Integer.MAX_VALUE;
+  // pool should be limited by the number of WriteThreads configured in
+  // collectd
+  final private int POOL_MAX_SIZE = Integer.MAX_VALUE;
 
-    public WriteNSQPlugin() {
-        Collectd.registerConfig(WriteNSQPlugin.class.getName(), this);
-        Collectd.registerShutdown(WriteNSQPlugin.class.getName(), this);
-        Collectd.registerWrite(WriteNSQPlugin.class.getName(), this);
-    }
+  public WriteNSQPlugin() {
+    Collectd.registerConfig(WriteNSQPlugin.class.getName(), this);
+    Collectd.registerShutdown(WriteNSQPlugin.class.getName(), this);
+    Collectd.registerWrite(WriteNSQPlugin.class.getName(), this);
+  }
 
-    public int write(ValueList vl) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(baos);
-        super.process(vl, out);
-        CloseableHttpClient client = null;
+  @Override
+  public int write(ValueList vl) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(baos);
+    super.process(vl, out);
+    CloseableHttpClient client = null;
+    try {
+      out.flush();
+      HttpPost post = new HttpPost(endpoint);
+      EntityBuilder request = EntityBuilder.create();
+      request.setBinary(baos.toByteArray());
+      post.setEntity(request.build());
+      client = clientPool.borrowObject();
+      CloseableHttpResponse response = client.execute(post);
+      try {
+        int code = response.getStatusLine().getStatusCode();
+        String msg = response.getStatusLine().getReasonPhrase();
+        // Consume the entire response so the connection will be reused
+        EntityUtils.consume(response.getEntity());
+        if (code != HttpStatus.SC_OK) {
+          Collectd.logInfo("Code: " + code + ", msg: " + msg);
+        }
+      } finally {
+        response.close();
+      }
+    } catch (Exception e) {
+      Collectd.logError("Error sending metrics to NSQ: " + e.getMessage());
+      if (client != null) {
         try {
-            out.flush();
-            HttpPost post = new HttpPost(endpoint);
-            EntityBuilder request = EntityBuilder.create();
-            request.setBinary(baos.toByteArray());
-            post.setEntity(request.build());
-            client = clientPool.borrowObject();
-            CloseableHttpResponse response = client.execute(post);
-            try {
-                int code = response.getStatusLine().getStatusCode();
-                String msg = response.getStatusLine().getReasonPhrase();
-                // Consume the entire response so the connection will be reused
-                EntityUtils.consume(response.getEntity());
-                if (code != HttpStatus.SC_OK) {
-                    Collectd.logInfo("Code: " + code + ", msg: " + msg);
-                }
-            } finally {
-                response.close();
-            }
-        } catch (Exception e) {
-            Collectd.logError("Error sending metrics to NSQ: " + e.getMessage());
-            if (client != null) {
-                try {
-                    client.close();
-                } catch (IOException e1) {
-                }
-                try {
-                    clientPool.invalidateObject(client);
-                } catch (Exception e2) {
-                }
-            }
-        } finally {
-            if (client != null) {
-                clientPool.returnObject(client);
-            }
-            if (null != out) {
-                try {
-                    out.close();
-                } catch (IOException e) {
-                }
-            }
-        }
-        return 0;
-    }
-
-    @Override
-    public void write(String metric, OutputStream out) {
+          client.close();
+        } catch (IOException e1) {}
         try {
-            ((DataOutputStream) out).writeBytes(metric);
-        } catch (IOException e) {
-            Collectd.logError("Error writing metric: " + e.getMessage());
-            try {
-                out.close(); // Should cause IOException in write.
-            } catch (IOException e1) {
-            }
-        }
+          clientPool.invalidateObject(client);
+        } catch (Exception e2) {}
+      }
+    } finally {
+      if (client != null) {
+        clientPool.returnObject(client);
+      }
+      if (null != out) {
+        try {
+          out.close();
+        } catch (IOException e) {}
+      }
     }
+    return 0;
+  }
 
-    public int shutdown() {
-        Collectd.logInfo("Shutting down connection to NSQ at " + host + ":" + port);
-        clientPool.close();
-        return 0;
+  @Override
+  public void write(String metric, OutputStream out) {
+    try {
+      ((DataOutputStream) out).writeBytes(metric);
+    } catch (IOException e) {
+      Collectd.logError("Error writing metric: " + e.getMessage());
+      try {
+        out.close(); // Should cause IOException in write.
+      } catch (IOException e1) {}
     }
+  }
 
-    public int config(OConfigItem config) {
-        super.config(config);
-        GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
-        // use max size for maxTotal and maxIdle
-        // no need to activate or passivate
-        poolConfig.setMaxTotal(POOL_MAX_SIZE);
-        poolConfig.setMaxIdle(POOL_MAX_SIZE);
-        poolConfig.setTestOnReturn(true);
-        PooledCloseableHttpClientFactory pooledCloseableHttpClientFactory = new PooledCloseableHttpClientFactory();
-        pooledCloseableHttpClientFactory.config(config);
+  @Override
+  public int shutdown() {
+    Collectd.logInfo("Shutting down connection to NSQ at " + host + ":" + port);
+    clientPool.close();
+    return 0;
+  }
 
-        for (OConfigItem child : config.getChildren()) {
-            switch (child.getKey()) {
-                case "host":
-                case "hostname":
-                case "Host":
-                case "HostName":
-                    String hostString = child.getValues().get(0).getString();
-                    String[] hosts = hostString.split(",");
-                    if (hosts.length == 1) {
-                        host = hosts[0];
-                    } else {
-                        host = hosts[new Random().nextInt(hosts.length)];
-                    }
-                    break;
-                case "Port":
-                case "port":
-                    port = Integer.parseInt(child.getValues().get(0).getString());
-                    break;
-                case "topic":
-                case "Topic":
-                    topic = child.getValues().get(0).getString();
-                    break;
-                default:
-            }
-        }
-        if (host == null || port == 0 || topic == null) {
-            Collectd.logError("NSQ host, port, and topic must be configured");
-            return -1;
-        }
-        this.clientPool = new GenericObjectPool(pooledCloseableHttpClientFactory, poolConfig);
-        this.endpoint = "http://" + host + ":" + port + "/mpub?topic=" + topic;
-        return 0;
+  @Override
+  public int config(OConfigItem config) {
+    super.config(config);
+    GenericObjectPoolConfig<CloseableHttpClient> poolConfig = new GenericObjectPoolConfig<>();
+    // use max size for maxTotal and maxIdle
+    // no need to activate or passivate
+    poolConfig.setMaxTotal(POOL_MAX_SIZE);
+    poolConfig.setMaxIdle(POOL_MAX_SIZE);
+    poolConfig.setTestOnReturn(true);
+    PooledCloseableHttpClientFactory pooledCloseableHttpClientFactory =
+        new PooledCloseableHttpClientFactory();
+    pooledCloseableHttpClientFactory.config(config);
+
+    for (OConfigItem child : config.getChildren()) {
+      switch (child.getKey()) {
+        case "host":
+        case "hostname":
+        case "Host":
+        case "HostName":
+          String hostString = child.getValues().get(0).getString();
+          String[] hosts = hostString.split(",");
+          if (hosts.length == 1) {
+            host = hosts[0];
+          } else {
+            host = hosts[new Random().nextInt(hosts.length)];
+          }
+          break;
+        case "Port":
+        case "port":
+          port = Integer.parseInt(child.getValues().get(0).getString());
+          break;
+        case "topic":
+        case "Topic":
+          topic = child.getValues().get(0).getString();
+          break;
+        default:
+      }
     }
+    if (host == null || port == 0 || topic == null) {
+      Collectd.logError("NSQ host, port, and topic must be configured");
+      return -1;
+    }
+    this.clientPool = new GenericObjectPool<>(pooledCloseableHttpClientFactory, poolConfig);
+    this.endpoint = "http://" + host + ":" + port + "/mpub?topic=" + topic;
+    return 0;
+  }
 
 }

--- a/collectd-timely-plugin/src/main/java/timely/collectd/plugin/PooledSocketFactory.java
+++ b/collectd-timely-plugin/src/main/java/timely/collectd/plugin/PooledSocketFactory.java
@@ -8,7 +8,7 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.collectd.api.Collectd;
 import org.collectd.api.OConfigItem;
 
-public class PooledSocketFactory implements PooledObjectFactory {
+public class PooledSocketFactory implements PooledObjectFactory<Socket> {
 
     private String host = null;
     private int port = 0;
@@ -81,12 +81,12 @@ public class PooledSocketFactory implements PooledObjectFactory {
     }
 
     @Override
-    public PooledObject makeObject() throws Exception {
-        return new DefaultPooledObject(connect());
+    public PooledObject<Socket> makeObject() throws Exception {
+        return new DefaultPooledObject<>(connect());
     }
 
     @Override
-    public void destroyObject(PooledObject pooledObject) throws Exception {
+    public void destroyObject(PooledObject<Socket> pooledObject) throws Exception {
         try {
             Collectd.logDebug("Shutting down connection to Timely at " + host + ":" + port);
             Socket socket = (Socket) pooledObject.getObject();
@@ -103,7 +103,7 @@ public class PooledSocketFactory implements PooledObjectFactory {
     }
 
     @Override
-    public boolean validateObject(PooledObject pooledObject) {
+    public boolean validateObject(PooledObject<Socket> pooledObject) {
         if (connectionTimeToLive > -1) {
             if (System.currentTimeMillis() > pooledObject.getCreateTime() + connectionTimeToLive) {
                 return false;
@@ -114,12 +114,12 @@ public class PooledSocketFactory implements PooledObjectFactory {
     }
 
     @Override
-    public void activateObject(PooledObject pooledObject) throws Exception {
+    public void activateObject(PooledObject<Socket> pooledObject) throws Exception {
         // do nothing
     }
 
     @Override
-    public void passivateObject(PooledObject pooledObject) throws Exception {
+    public void passivateObject(PooledObject<Socket> pooledObject) throws Exception {
         // do nothing
     }
 }

--- a/collectd-timely-plugin/src/main/java/timely/collectd/plugin/WriteTimelyPlugin.java
+++ b/collectd-timely-plugin/src/main/java/timely/collectd/plugin/WriteTimelyPlugin.java
@@ -86,13 +86,13 @@ public class WriteTimelyPlugin extends CollectDPluginParent
         PooledSocketFactory socketFactory = new PooledSocketFactory();
         retval = socketFactory.config(config);
         if (retval == 0) {
-            GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+            GenericObjectPoolConfig<Socket> poolConfig = new GenericObjectPoolConfig<>();
             // use max size for maxTotal and maxIdle
             // no need to activate and passivate
             poolConfig.setMaxTotal(POOL_MAX_SIZE);
             poolConfig.setMaxIdle(POOL_MAX_SIZE);
             poolConfig.setTestOnReturn(true);
-            socketPool = new GenericObjectPool(socketFactory, poolConfig);
+            socketPool = new GenericObjectPool<>(socketFactory, poolConfig);
         }
         return retval;
     }

--- a/grafana-auth/pom.xml
+++ b/grafana-auth/pom.xml
@@ -166,7 +166,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${version.netty-tcnative}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/grafana-auth/src/main/java/timely/grafana/auth/configuration/GrafanaAuthConfiguration.java
+++ b/grafana-auth/src/main/java/timely/grafana/auth/configuration/GrafanaAuthConfiguration.java
@@ -43,8 +43,6 @@ public class GrafanaAuthConfiguration {
     /**
      * Time to wait (in seconds) for connections to finish and to make sure no new
      * connections happen before shutting down Netty event loop groups.
-     *
-     * @return
      */
     public int getShutdownQuietPeriod() {
         return this.shutdownQuietPeriod;

--- a/grafana-auth/src/main/java/timely/grafana/auth/netty/http/GrafanaRequestDecoder.java
+++ b/grafana-auth/src/main/java/timely/grafana/auth/netty/http/GrafanaRequestDecoder.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Multimap;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import org.apache.commons.lang3.StringUtils;
@@ -47,7 +47,7 @@ public class GrafanaRequestDecoder extends MessageToMessageDecoder<FullHttpReque
 
     public static String getSessionId(FullHttpRequest msg) {
         Multimap<String, String> headers = HttpHeaderUtils.toMultimap(msg.headers());
-        Collection<String> cookies = headers.get(Names.COOKIE);
+        Collection<String> cookies = headers.get(HttpHeaderNames.COOKIE.toString());
         final StringBuilder buf = new StringBuilder();
         cookies.forEach(h -> {
             ServerCookieDecoder.STRICT.decode(h).forEach(c -> {
@@ -70,7 +70,7 @@ public class GrafanaRequestDecoder extends MessageToMessageDecoder<FullHttpReque
 
         LOG.trace(LOG_RECEIVED_REQUEST, msg);
 
-        final String uri = msg.getUri();
+        final String uri = msg.uri();
         final QueryStringDecoder decoder = new QueryStringDecoder(uri);
         if (decoder.path().equals(nonSecureRedirectAddress)) {
             out.add(new StrictTransportResponse());

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <version.accumulo>1.9.2</version.accumulo>
+    <version.accumulo>1.9.3</version.accumulo>
     <version.buildnumber-maven>1.4</version.buildnumber-maven>
     <version.caffeine>2.6.2</version.caffeine>
     <version.collectd>5.7.1</version.collectd>
@@ -58,7 +58,7 @@
     <version.hadoop>2.7.3</version.hadoop>
     <version.httpcomponents>4.5.6</version.httpcomponents>
     <version.impsort>1.2.0</version.impsort>
-    <version.jackson>2.9.8</version.jackson>
+    <version.jackson>2.9.9</version.jackson>
     <version.jacoco>0.7.6.201602180812</version.jacoco>
     <version.javacsv>2.0</version.javacsv>
     <version.javassist>3.24.1-GA</version.javassist>
@@ -145,6 +145,11 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${version.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>${version.netty-tcnative}</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.javacsv</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -150,7 +150,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${version.netty-tcnative}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/server/src/main/java/timely/adapter/accumulo/MetaAdapter.java
+++ b/server/src/main/java/timely/adapter/accumulo/MetaAdapter.java
@@ -1,27 +1,13 @@
 package timely.adapter.accumulo;
 
-import org.apache.accumulo.core.client.lexicoder.LongLexicoder;
-import org.apache.accumulo.core.client.lexicoder.PairLexicoder;
-import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
 import org.apache.accumulo.core.data.Key;
 import timely.api.model.Meta;
 import timely.model.Metric;
-import timely.model.parse.TagListParser;
-import timely.model.parse.TagParser;
 
 /**
  * Creates Accumulo data structures from {@link Metric}
  */
 public class MetaAdapter {
-
-    private static final PairLexicoder<String, Long> rowCoder = new PairLexicoder<>(new StringLexicoder(),
-            new LongLexicoder());
-
-    private static final PairLexicoder<Long, String> colQualCoder = new PairLexicoder<>(new LongLexicoder(),
-            new StringLexicoder());
-
-    private static final TagParser tagParser = new TagParser();
-    private static final TagListParser tagListParser = new TagListParser();
 
     public static Key createMetricKey(String metricName, Long timestamp) {
         return new Key(Meta.METRIC_PREFIX + metricName, "", "", timestamp);

--- a/server/src/main/java/timely/api/request/TcpRequest.java
+++ b/server/src/main/java/timely/api/request/TcpRequest.java
@@ -4,8 +4,6 @@ public interface TcpRequest extends Request {
 
     /**
      * Parse a line of text received and populate this object
-     * 
-     * @param line
      */
     public void parse(String line);
 

--- a/server/src/main/java/timely/api/request/UdpRequest.java
+++ b/server/src/main/java/timely/api/request/UdpRequest.java
@@ -4,8 +4,6 @@ public interface UdpRequest {
 
     /**
      * Parse a line of text received and populate this object
-     * 
-     * @param line
      */
     public void parse(String line);
 

--- a/server/src/main/java/timely/api/response/timeseries/MetricsResponse.java
+++ b/server/src/main/java/timely/api/response/timeseries/MetricsResponse.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
@@ -129,8 +129,8 @@ public class MetricsResponse {
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, responseType);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, responseType);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         return response;
     }
 

--- a/server/src/main/java/timely/auth/AuthenticationService.java
+++ b/server/src/main/java/timely/auth/AuthenticationService.java
@@ -43,9 +43,13 @@ public class AuthenticationService {
         try {
             springContext = new ClassPathXmlApplicationContext("security.xml");
             authManager = springContext.getBean("authenticationManager", AuthenticationManager.class);
-            requiredRoles = springContext.getBean("requiredRoles", List.class);
+            @SuppressWarnings("unchecked")
+            List<String> uncheckedRoles = springContext.getBean("requiredRoles", List.class);
+            requiredRoles = uncheckedRoles;
             requiredRoles.removeIf(String::isEmpty);
-            requiredAuths = springContext.getBean("requiredAuths", List.class);
+            @SuppressWarnings("unchecked")
+            List<String> uncheckedAuths = springContext.getBean("requiredAuths", List.class);
+            requiredAuths = uncheckedAuths;
             requiredAuths.removeIf(String::isEmpty);
         } catch (BeansException e) {
             throw new ServiceConfigurationError("Error setting up Authentication objects: " + e.getMessage(),

--- a/server/src/main/java/timely/auth/ScannerBaseDelegate.java
+++ b/server/src/main/java/timely/auth/ScannerBaseDelegate.java
@@ -16,8 +16,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.thrift.IterInfo;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A simple wrapper around a {@link ScannerBase} that overrides the methods that
@@ -27,7 +25,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ScannerBaseDelegate implements ScannerBase {
 
-    private static final Logger log = LoggerFactory.getLogger(ScannerBaseDelegate.class);
     private static final String SYSTEM_ITERATOR_NAME_PREFIX = "sys_";
 
     protected final ScannerBase delegate;
@@ -139,10 +136,11 @@ public class ScannerBaseDelegate implements ScannerBase {
     @Override
     public void clearScanIterators() {
         if (delegate instanceof ScannerOptions) {
-            ScannerOptionsHelper opts = new ScannerOptionsHelper((ScannerOptions) delegate);
-            for (IteratorSetting iteratorSetting : opts.getIterators()) {
-                if (!iteratorSetting.getName().startsWith(SYSTEM_ITERATOR_NAME_PREFIX)) {
-                    delegate.removeScanIterator(iteratorSetting.getName());
+            try (ScannerOptionsHelper opts = new ScannerOptionsHelper((ScannerOptions) delegate)) {
+                for (IteratorSetting iteratorSetting : opts.getIterators()) {
+                    if (!iteratorSetting.getName().startsWith(SYSTEM_ITERATOR_NAME_PREFIX)) {
+                        delegate.removeScanIterator(iteratorSetting.getName());
+                    }
                 }
             }
         } else {

--- a/server/src/main/java/timely/auth/SubjectIssuerDNPair.java
+++ b/server/src/main/java/timely/auth/SubjectIssuerDNPair.java
@@ -13,6 +13,7 @@ import timely.auth.util.ProxiedEntityUtils;
  */
 public class SubjectIssuerDNPair implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private final String subjectDN;
     private final String issuerDN;
 

--- a/server/src/main/java/timely/auth/TimelyPrincipal.java
+++ b/server/src/main/java/timely/auth/TimelyPrincipal.java
@@ -29,6 +29,7 @@ import timely.auth.util.DnUtils;
 @XmlAccessorType(XmlAccessType.NONE)
 public class TimelyPrincipal implements Principal, Serializable {
 
+    private static final long serialVersionUID = 1L;
     private final String username;
     private final TimelyUser primaryUser;
     @XmlElement
@@ -103,7 +104,7 @@ public class TimelyPrincipal implements Principal, Serializable {
 
     public Set<String> getProxyServers() {
 
-        // @formatter:off
+    // @formatter:off
         Set<String> proxyServers = getProxiedUsers().stream()
                 .filter(u -> u.getUserType() == TimelyUser.UserType.SERVER)
                 .map(TimelyUser::getDn)

--- a/server/src/main/java/timely/auth/TimelyUser.java
+++ b/server/src/main/java/timely/auth/TimelyUser.java
@@ -20,6 +20,8 @@ import timely.auth.util.DnUtils;
  */
 public class TimelyUser implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     public enum UserType {
         USER, SERVER
     }

--- a/server/src/main/java/timely/auth/util/HttpHeaderUtils.java
+++ b/server/src/main/java/timely/auth/util/HttpHeaderUtils.java
@@ -13,7 +13,9 @@ public class HttpHeaderUtils {
         Multimap<String, String> headerMultimap = HashMultimap.create();
         if (headers != null) {
             for (Map.Entry<String, String> e : headers.entries()) {
-                headerMultimap.put(e.getKey(), e.getValue());
+                // lower case for HTTP/2 compatibility; even for HTTP/1, these were always
+                // case-insensitive
+                headerMultimap.put(e.getKey().toLowerCase(), e.getValue());
             }
         }
         return headerMultimap;
@@ -22,6 +24,9 @@ public class HttpHeaderUtils {
     public static String getSingleHeader(Multimap<String, String> headers, String headerName, boolean enforceOneValue)
             throws IllegalArgumentException {
         String value = null;
+        // lower case for HTTP/2 compatibility; even for HTTP/1, these were always
+        // case-insensitive
+        headerName = headerName.toLowerCase();
         Collection<String> values = (headers == null) ? null : headers.get(headerName);
         if (values != null && !values.isEmpty()) {
             if (values.size() > 1 && enforceOneValue) {

--- a/server/src/main/java/timely/configuration/Accumulo.java
+++ b/server/src/main/java/timely/configuration/Accumulo.java
@@ -1,8 +1,8 @@
 package timely.configuration;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
-import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Accumulo {

--- a/server/src/main/java/timely/configuration/Http.java
+++ b/server/src/main/java/timely/configuration/Http.java
@@ -1,9 +1,9 @@
 package timely.configuration;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Http {

--- a/server/src/main/java/timely/configuration/Server.java
+++ b/server/src/main/java/timely/configuration/Server.java
@@ -1,8 +1,7 @@
 package timely.configuration;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-
-import org.hibernate.validator.constraints.NotBlank;
 
 public class Server {
 
@@ -42,8 +41,6 @@ public class Server {
     /**
      * Time to wait (in seconds) for connections to finish and to make sure no new
      * connections happen before shutting down Netty event loop groups.
-     *
-     * @return
      */
     public int getShutdownQuietPeriod() {
         return this.shutdownQuietPeriod;

--- a/server/src/main/java/timely/configuration/Websocket.java
+++ b/server/src/main/java/timely/configuration/Websocket.java
@@ -1,8 +1,7 @@
 package timely.configuration;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-
-import org.hibernate.validator.constraints.NotBlank;
 
 public class Websocket {
 

--- a/server/src/main/java/timely/netty/http/HttpCacheRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/HttpCacheRequestHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import timely.api.request.CacheRequest;
@@ -35,8 +35,8 @@ public class HttpCacheRequestHandler extends SimpleChannelInboundHandler<CacheRe
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/HttpMetricPutHandler.java
+++ b/server/src/main/java/timely/netty/http/HttpMetricPutHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -35,8 +35,8 @@ public class HttpMetricPutHandler extends SimpleChannelInboundHandler<MetricRequ
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.EMPTY_BUFFER);
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/HttpVersionRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/HttpVersionRequestHandler.java
@@ -7,7 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import timely.api.request.VersionRequest;
@@ -20,8 +20,8 @@ public class HttpVersionRequestHandler extends SimpleChannelInboundHandler<Versi
     protected void channelRead0(ChannelHandlerContext ctx, VersionRequest v) throws Exception {
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(VersionRequest.VERSION.getBytes(StandardCharsets.UTF_8)));
-        response.headers().set(Names.CONTENT_TYPE, Constants.TEXT_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.TEXT_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/NonSslRedirectHandler.java
+++ b/server/src/main/java/timely/netty/http/NonSslRedirectHandler.java
@@ -6,7 +6,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -51,7 +51,7 @@ public class NonSslRedirectHandler extends OptionalSslHandler implements TimelyH
                 LOG.trace("Received non-SSL request, returning redirect");
                 FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                         HttpResponseStatus.MOVED_PERMANENTLY, Unpooled.EMPTY_BUFFER);
-                response.headers().set(Names.LOCATION, redirectAddress);
+                response.headers().set(HttpHeaderNames.LOCATION, redirectAddress);
                 LOG.trace(Constants.LOG_RETURNING_RESPONSE, response);
                 encoder.write(ctx, response, ctx.voidPromise());
                 ctx.flush();

--- a/server/src/main/java/timely/netty/http/TimelyHttpHandler.java
+++ b/server/src/main/java/timely/netty/http/TimelyHttpHandler.java
@@ -6,7 +6,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -25,8 +25,8 @@ public interface TimelyHttpHandler {
                 .writeValueAsBytes("ResponseCode: " + e.getCode() + " Message: " + e.getMessage());
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.valueOf(e.getCode()), Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         e.getResponseHeaders().entrySet().forEach(entry -> response.headers().set(entry.getKey(), entry.getValue()));
         // Send the error response
         sendResponse(ctx, response);

--- a/server/src/main/java/timely/netty/http/auth/TimelyAuthenticationToken.java
+++ b/server/src/main/java/timely/netty/http/auth/TimelyAuthenticationToken.java
@@ -17,9 +17,10 @@ import timely.auth.util.HttpHeaderUtils;
 
 public class TimelyAuthenticationToken extends PreAuthenticatedAuthenticationToken {
 
+    private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(TimelyAuthenticationToken.class);
-    public static final String PROXIED_ENTITIES_HEADER = "X-ProxiedEntitiesChain";
-    public static final String PROXIED_ISSUERS_HEADER = "X-ProxiedIssuersChain";
+    public static final String PROXIED_ENTITIES_HEADER = "x-proxiedentitieschain";
+    public static final String PROXIED_ISSUERS_HEADER = "x-proxiedissuerschain";
 
     private Multimap<String, String> httpHeaders = null;
     private X509Certificate clientCert = null;

--- a/server/src/main/java/timely/netty/http/auth/TimelyLoginRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/auth/TimelyLoginRequestHandler.java
@@ -8,7 +8,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
@@ -43,22 +43,22 @@ public abstract class TimelyLoginRequestHandler<T> extends SimpleChannelInboundH
                     principal.getPrimaryUser().getDn().subjectDN());
             String sessionIdEncoded = URLEncoder.encode(sessionId, StandardCharsets.UTF_8.name());
             FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-            response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-            response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+            response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             DefaultCookie cookie = new DefaultCookie(Constants.COOKIE_NAME, sessionIdEncoded);
             cookie.setDomain(domain);
             cookie.setMaxAge(maxAge);
             cookie.setPath("/");
             cookie.setHttpOnly(true);
             cookie.setSecure(true);
-            response.headers().set(Names.SET_COOKIE, ServerCookieEncoder.STRICT.encode(cookie));
+            response.headers().set(HttpHeaderNames.SET_COOKIE, ServerCookieEncoder.STRICT.encode(cookie));
             sendResponse(ctx, response);
         } catch (Exception e) {
             LOG.error("Login failure", e);
             FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                     HttpResponseStatus.UNAUTHORIZED);
-            response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-            response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+            response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             sendResponse(ctx, response);
         }
 

--- a/server/src/main/java/timely/netty/http/timeseries/HttpAggregatorsRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/timeseries/HttpAggregatorsRequestHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import timely.api.request.timeseries.AggregatorsRequest;
@@ -22,8 +22,8 @@ public class HttpAggregatorsRequestHandler extends SimpleChannelInboundHandler<A
         byte[] buf = JsonUtil.getObjectMapper().writeValueAsBytes(AggregatorsResponse.RESPONSE);
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/timeseries/HttpMetricsRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/timeseries/HttpMetricsRequestHandler.java
@@ -2,7 +2,7 @@ package timely.netty.http.timeseries;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import timely.api.request.timeseries.MetricsRequest;
 import timely.api.response.timeseries.MetricsResponse;
 import timely.configuration.Configuration;
@@ -20,7 +20,7 @@ public class HttpMetricsRequestHandler extends SimpleChannelInboundHandler<Metri
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, MetricsRequest msg) throws Exception {
         MetricsResponse r = new MetricsResponse(conf);
-        String acceptHeader = msg.getRequestHeader(Names.ACCEPT);
+        String acceptHeader = msg.getRequestHeader(HttpHeaderNames.ACCEPT.toString());
         sendResponse(ctx, r.toHttpResponse(acceptHeader));
     }
 

--- a/server/src/main/java/timely/netty/http/timeseries/HttpQueryRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/timeseries/HttpQueryRequestHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -42,8 +42,8 @@ public class HttpQueryRequestHandler extends SimpleChannelInboundHandler<QueryRe
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/timeseries/HttpSearchLookupRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/timeseries/HttpSearchLookupRequestHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -39,8 +39,8 @@ public class HttpSearchLookupRequestHandler extends SimpleChannelInboundHandler<
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/netty/http/timeseries/HttpSuggestRequestHandler.java
+++ b/server/src/main/java/timely/netty/http/timeseries/HttpSuggestRequestHandler.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -39,8 +39,8 @@ public class HttpSuggestRequestHandler extends SimpleChannelInboundHandler<Sugge
         }
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(buf));
-        response.headers().set(Names.CONTENT_TYPE, Constants.JSON_TYPE);
-        response.headers().set(Names.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, Constants.JSON_TYPE);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         sendResponse(ctx, response);
     }
 

--- a/server/src/main/java/timely/sample/iterators/AggregationIterator.java
+++ b/server/src/main/java/timely/sample/iterators/AggregationIterator.java
@@ -37,7 +37,6 @@ public class AggregationIterator extends WrappingIterator {
     private Set<Tag> tags;
     private Key last;
 
-    @SuppressWarnings("unchecked")
     @Override
     public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env)
             throws IOException {
@@ -45,7 +44,10 @@ public class AggregationIterator extends WrappingIterator {
         String aggClassname = options.get(AGGCLASS);
         Class<? extends Aggregator> aggClass = null;
         try {
-            aggClass = (Class<? extends Aggregator>) this.getClass().getClassLoader().loadClass(aggClassname);
+            @SuppressWarnings("unchecked")
+            Class<? extends Aggregator> uncheckedAggClass = (Class<? extends Aggregator>) this.getClass()
+                    .getClassLoader().loadClass(aggClassname);
+            aggClass = uncheckedAggClass;
             tags = new HashSet<>(new TagListParser().parse(options.get(TAGS)));
             aggregation = new Aggregation(aggClass.newInstance());
         } catch (ClassNotFoundException e) {
@@ -119,10 +121,11 @@ public class AggregationIterator extends WrappingIterator {
         is.addOption(AGGCLASS, classname);
     }
 
-    @SuppressWarnings("unchecked")
     public static Map<Set<Tag>, Aggregation> decodeValue(Value value) throws IOException, ClassNotFoundException {
         ByteArrayInputStream bis = new ByteArrayInputStream(value.get());
         ObjectInputStream ois = new ObjectInputStream(bis);
-        return (Map<Set<Tag>, Aggregation>) ois.readObject();
+        @SuppressWarnings("unchecked")
+        Map<Set<Tag>, Aggregation> unchecked = (Map<Set<Tag>, Aggregation>) ois.readObject();
+        return unchecked;
     }
 }

--- a/server/src/main/java/timely/sample/iterators/DownsampleIterator.java
+++ b/server/src/main/java/timely/sample/iterators/DownsampleIterator.java
@@ -51,7 +51,6 @@ public class DownsampleIterator extends WrappingIterator {
 
     private DownsampleMemoryEstimator memoryEstimator = null;
 
-    @SuppressWarnings("unchecked")
     @Override
     public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env)
             throws IOException {
@@ -73,7 +72,9 @@ public class DownsampleIterator extends WrappingIterator {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
-        factory = new DownsampleFactory(start, end, period, (Class<? extends Aggregator>) aggClass);
+        @SuppressWarnings("unchecked")
+        Class<? extends Aggregator> uncheckedAggClass = (Class<? extends Aggregator>) aggClass;
+        factory = new DownsampleFactory(start, end, period, uncheckedAggClass);
     }
 
     @Override
@@ -154,11 +155,12 @@ public class DownsampleIterator extends WrappingIterator {
         is.addOption(AGGCLASS, classname);
     }
 
-    @SuppressWarnings("unchecked")
     public static Map<Set<Tag>, Downsample> decodeValue(Value value) throws IOException, ClassNotFoundException {
         ByteArrayInputStream bis = new ByteArrayInputStream(value.get());
         ObjectInputStream ois = new ObjectInputStream(bis);
-        return (Map<Set<Tag>, Downsample>) ois.readObject();
+        @SuppressWarnings("unchecked")
+        Map<Set<Tag>, Downsample> unchecked = (Map<Set<Tag>, Downsample>) ois.readObject();
+        return unchecked;
     }
 
     public static long getDownsamplePeriod(QueryRequest.SubQuery query) {

--- a/server/src/main/java/timely/store/MetaCacheImpl.java
+++ b/server/src/main/java/timely/store/MetaCacheImpl.java
@@ -1,7 +1,6 @@
 package timely.store;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -22,7 +21,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.configuration.BaseConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import timely.api.model.Meta;
@@ -56,11 +54,11 @@ public class MetaCacheImpl implements MetaCache {
 
     private void refreshCache(long expirationMinutes) {
         long oldestTimestamp = System.currentTimeMillis() - (expirationMinutes * 60 * 1000);
-        final BaseConfiguration apacheConf = new BaseConfiguration();
+        Map<String, String> properties = new HashMap<>();
         Accumulo accumuloConf = configuration.getAccumulo();
-        apacheConf.setProperty("instance.name", accumuloConf.getInstanceName());
-        apacheConf.setProperty("instance.zookeeper.host", accumuloConf.getZookeepers());
-        final ClientConfiguration aConf = new ClientConfiguration(Collections.singletonList(apacheConf));
+        properties.put("instance.name", accumuloConf.getInstanceName());
+        properties.put("instance.zookeeper.host", accumuloConf.getZookeepers());
+        final ClientConfiguration aConf = ClientConfiguration.fromMap(properties);
         String metaTable = configuration.getMetaTable();
         Map<String, Map<String, Long>> metricMap = new HashMap<>();
         Scanner scanner = null;

--- a/server/src/main/java/timely/store/MetricAgeOffIterator.java
+++ b/server/src/main/java/timely/store/MetricAgeOffIterator.java
@@ -143,8 +143,8 @@ public class MetricAgeOffIterator extends WrappingIterator implements OptionDesc
             byte[] newStartRow = MetricAdapter.encodeRowKey(start.getFirst(), timeTarget);
             // @formatter:off
             Key newStartKey = new Key(newStartRow, 
-            		null != startKey.getColumnFamily() ? startKey.getColumnFamilyData().getBackingArray() : null, 
-            		null != startKey.getColumnQualifier() ? startKey.getColumnQualifierData().getBackingArray() : null,
+                    null != startKey.getColumnFamily() ? startKey.getColumnFamilyData().getBackingArray() : null, 
+                    null != startKey.getColumnQualifier() ? startKey.getColumnQualifierData().getBackingArray() : null,
                     null != startKey.getColumnVisibility() ? startKey.getColumnVisibility().getBytes() : null,
                     timeTarget, startKey.isDeleted());
             // @formatter:on

--- a/server/src/main/java/timely/store/cache/OrderedTags.java
+++ b/server/src/main/java/timely/store/cache/OrderedTags.java
@@ -41,7 +41,7 @@ public class OrderedTags {
     }
 
     public Map<String, String> getTags() {
-        Map<String, String> t = new LinkedHashMap();
+        Map<String, String> t = new LinkedHashMap<>();
         for (Pair<String, String> p : tagSet) {
             t.put(p.getLeft(), p.getRight());
         }

--- a/server/src/main/java/timely/store/cache/WrappedGorillaCompressor.java
+++ b/server/src/main/java/timely/store/cache/WrappedGorillaCompressor.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.Range;
 
 public class WrappedGorillaCompressor implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private boolean closed = false;
     private long numEntries = 0;
     private long oldestTimestamp;
@@ -18,10 +19,6 @@ public class WrappedGorillaCompressor implements Serializable {
     private LongArrayOutput compressorOutput = null;
     private long[] backingArray = null;
     private GorillaCompressor compressor;
-
-    private WrappedGorillaCompressor() {
-
-    }
 
     public WrappedGorillaCompressor(long timestamp) {
         this.compressorOutput = new LongArrayOutput(16);

--- a/server/src/main/java/timely/store/iterators/TimeSeriesGroupingIterator.java
+++ b/server/src/main/java/timely/store/iterators/TimeSeriesGroupingIterator.java
@@ -2,7 +2,14 @@ package timely.store.iterators;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -28,19 +35,19 @@ import timely.model.Metric;
  * number of elements in the filter. So, if you have a five day moving average
  * filter and a time series as 100 data points, then you will receive 95
  * results.
- * 
+ *
  * For multiple time series, K/V pairs will be reported in time order where time
  * is taken from the key of the last element in the filter. For example, if you
  * have series {A,B,C} and {A,C} are on the same time interval and B is lagging
  * behind them, then this iterator will return K/V answers for the time series
  * in the following manner:
- * 
+ *
  * A, C, B, A, C, B, ...
- * 
+ *
  * Also of note is that this iterator handles new time series appearing in the
  * middle of the time range. Time series that disappear during the time range
  * will stop reporting an answer.
- * 
+ *
  * NOTE: This iterator does not handle being re-seeked. It is currently designed
  * to be used with the DownsampleIterator above it.
  *
@@ -222,8 +229,6 @@ public class TimeSeriesGroupingIterator extends WrappingIterator {
     /**
      * This will parse the next set of keys with the same timestamp (encoded in the
      * row) from the underlying source.
-     * 
-     * @throws IOException
      */
     private void refillBuffer() throws IOException {
         LOG.trace("refill()");

--- a/server/src/main/java/timely/testing/MetricQueryLoadTest.java
+++ b/server/src/main/java/timely/testing/MetricQueryLoadTest.java
@@ -153,7 +153,7 @@ public class MetricQueryLoadTest {
 
             long numQueries = 1000;
             long queriesCompleted = 0;
-            List<Future> futures = new ArrayList<>();
+            List<Future<?>> futures = new ArrayList<>();
 
             while (!testDone) {
                 testDone = (System.currentTimeMillis() - beginQueries) >= (testDurationMins * 60 * 1000);
@@ -164,9 +164,9 @@ public class MetricQueryLoadTest {
                     while (futures.size() < numQueries) {
                         futures.add(executorService.submit(runnableTask));
                     }
-                    Iterator<Future> itr = futures.iterator();
+                    Iterator<Future<?>> itr = futures.iterator();
                     while (itr.hasNext()) {
-                        Future f = itr.next();
+                        Future<?> f = itr.next();
                         if (f.isDone()) {
                             itr.remove();
                             queriesCompleted++;

--- a/server/src/main/java/timely/util/GetMetricTableSplitPoints.java
+++ b/server/src/main/java/timely/util/GetMetricTableSplitPoints.java
@@ -1,6 +1,7 @@
 package timely.util;
 
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.ClientConfiguration;
@@ -12,7 +13,6 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.commons.configuration.BaseConfiguration;
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -30,11 +30,11 @@ public class GetMetricTableSplitPoints {
                 .bannerMode(Mode.OFF).web(WebApplicationType.NONE).run(args)) {
             Configuration conf = ctx.getBean(Configuration.class);
 
-            final BaseConfiguration apacheConf = new BaseConfiguration();
+            final Map<String, String> properties = new HashMap<>();
             Accumulo accumuloConf = conf.getAccumulo();
-            apacheConf.setProperty("instance.name", accumuloConf.getInstanceName());
-            apacheConf.setProperty("instance.zookeeper.host", accumuloConf.getZookeepers());
-            final ClientConfiguration aconf = new ClientConfiguration(Collections.singletonList(apacheConf));
+            properties.put("instance.name", accumuloConf.getInstanceName());
+            properties.put("instance.zookeeper.host", accumuloConf.getZookeepers());
+            final ClientConfiguration aconf = ClientConfiguration.fromMap(properties);
             final Instance instance = new ZooKeeperInstance(aconf);
             Connector con = instance.getConnector(accumuloConf.getUsername(),
                     new PasswordToken(accumuloConf.getPassword()));

--- a/server/src/test/java/timely/api/request/subscription/WebSocketRequestDeserializationTest.java
+++ b/server/src/test/java/timely/api/request/subscription/WebSocketRequestDeserializationTest.java
@@ -12,11 +12,11 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testCreateDeserialization() throws Exception {
         // @formatter:off
-		String json = "{ "
-				       + "\"operation\" : \"create\","
-				       + " \"sessionId\": \"1234\""
-				    + "}";
-		// @formatter:on
+        String json = "{ "
+                       + "\"operation\" : \"create\","
+                       + " \"sessionId\": \"1234\""
+                    + "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(CreateSubscription.class, request.getClass());
@@ -26,12 +26,12 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testRemoveDeserialization() throws Exception {
         // @formatter:off
-		String json = "{ "
-				       + "\"operation\" : \"remove\","
-				       + " \"sessionId\": \"1234\","
-				       + " \"metric\" : \"sys.cpu.user\""
-				    + "}";
-		// @formatter:on
+        String json = "{ "
+                       + "\"operation\" : \"remove\","
+                       + " \"sessionId\": \"1234\","
+                       + " \"metric\" : \"sys.cpu.user\""
+                    + "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(RemoveSubscription.class, request.getClass());
@@ -42,11 +42,11 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testCloseDeserialization() throws Exception {
         // @formatter:off
-		String json = "{ "
-				       + "\"operation\" : \"close\","
-				       + " \"sessionId\": \"1234\""
-				    + "}";
-		// @formatter:on
+        String json = "{ "
+                       + "\"operation\" : \"close\","
+                       + " \"sessionId\": \"1234\""
+                    + "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(CloseSubscription.class, request.getClass());
@@ -56,12 +56,12 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testAddDeserialization() throws Exception {
         // @formatter:off
-		String json = "{" +
-						"\"operation\" : \"add\"," +
-						"\"sessionId\" : \"1234\"," +
-					    " \"metric\" : \"sys.cpu.user\"" +
-					  "}";
-		// @formatter:on
+        String json = "{" +
+                        "\"operation\" : \"add\"," +
+                        "\"sessionId\" : \"1234\"," +
+                        " \"metric\" : \"sys.cpu.user\"" +
+                      "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(AddSubscription.class, request.getClass());
@@ -74,13 +74,13 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testAddDeserializationWithTime() throws Exception {
         // @formatter:off
-		String json = "{" +
-						"\"operation\" : \"add\"," +
-						"\"sessionId\" : \"1234\"," +
-					    "\"metric\" : \"sys.cpu.user\"," +
-						"\"startTime\" : \"1000\"" +
-					  "}";
-		// @formatter:on
+        String json = "{" +
+                        "\"operation\" : \"add\"," +
+                        "\"sessionId\" : \"1234\"," +
+                        "\"metric\" : \"sys.cpu.user\"," +
+                        "\"startTime\" : \"1000\"" +
+                      "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(AddSubscription.class, request.getClass());
@@ -95,18 +95,18 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testAddDeserializationWithTimeAndTags() throws Exception {
         // @formatter:off
-		String json = "{" +
-						"\"operation\" : \"add\"," +
-						"\"sessionId\" : \"1234\"," +
-					    "\"metric\" : \"sys.cpu.user\"," +
-						"\"tags\" : {" +
-					       "\"tag2\" : \"value2\"," +
-					       "\"tag1\" : \"value1\"" +
-					    "}," +
-						"\"startTime\" : \"1000\"," +
-					    "\"endTime\" : \"2000\""+
-					  "}";
-		// @formatter:on
+        String json = "{" +
+                        "\"operation\" : \"add\"," +
+                        "\"sessionId\" : \"1234\"," +
+                        "\"metric\" : \"sys.cpu.user\"," +
+                        "\"tags\" : {" +
+                           "\"tag2\" : \"value2\"," +
+                           "\"tag1\" : \"value1\"" +
+                        "}," +
+                        "\"startTime\" : \"1000\"," +
+                        "\"endTime\" : \"2000\""+
+                      "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(AddSubscription.class, request.getClass());
@@ -129,18 +129,18 @@ public class WebSocketRequestDeserializationTest {
     @Test
     public void testAddDeserializationWithStartAndDelayTimeAndTags() throws Exception {
         // @formatter:off
-		String json = "{" +
-						"\"operation\" : \"add\"," +
-						"\"sessionId\" : \"1234\"," +
-					    "\"metric\" : \"sys.cpu.user\"," +
-						"\"tags\" : {" +
-					       "\"tag2\" : \"value2\"," +
-					       "\"tag1\" : \"value1\"" +
-					    "}," +
-						"\"startTime\" : \"1000\"," +
-					    "\"delayTime\" : \"500\"" +
-					  "}";
-		// @formatter:on
+        String json = "{" +
+                        "\"operation\" : \"add\"," +
+                        "\"sessionId\" : \"1234\"," +
+                        "\"metric\" : \"sys.cpu.user\"," +
+                        "\"tags\" : {" +
+                           "\"tag2\" : \"value2\"," +
+                           "\"tag1\" : \"value1\"" +
+                        "}," +
+                        "\"startTime\" : \"1000\"," +
+                        "\"delayTime\" : \"500\"" +
+                      "}";
+        // @formatter:on
         WebSocketRequest request = JsonUtil.getObjectMapper().readValue(json.getBytes(), WebSocketRequest.class);
         Assert.assertNotNull(request);
         Assert.assertEquals(AddSubscription.class, request.getClass());

--- a/server/src/test/java/timely/netty/http/HttpRequestDecoderTest.java
+++ b/server/src/test/java/timely/netty/http/HttpRequestDecoderTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
@@ -86,7 +86,7 @@ public class HttpRequestDecoderTest {
     }
 
     private void addCookie(FullHttpRequest request) {
-        request.headers().set(Names.COOKIE, ClientCookieEncoder.STRICT.encode(Constants.COOKIE_NAME, cookie));
+        request.headers().set(HttpHeaderNames.COOKIE, ClientCookieEncoder.STRICT.encode(Constants.COOKIE_NAME, cookie));
     }
 
     @Test
@@ -218,10 +218,10 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testLookupPostWithNoLimit() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
-        "    \"metric\": \"sys.cpu.user\"\n" + 
+        "    \"metric\": \"sys.cpu.user\"\n" +
         "}";
         // @formatter:on
         decoder = new TestHttpQueryDecoder(config);
@@ -255,8 +255,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testLookupPostWithLimit() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
         "    \"metric\": \"sys.cpu.user\",\n" +
         "    \"limit\": 3000\n" +
@@ -296,8 +296,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testLookupPostWithLimitAndTags() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
         "    \"metric\": \"sys.cpu.user\",\n" +
         "    \"limit\": 3000,\n" +
@@ -411,8 +411,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testSuggestPostWithValidType() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
         "    \"type\": \"metrics\"\n" +
         "}";
@@ -450,8 +450,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testSuggestPostWithValidTypeAndQuery() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
         "    \"type\": \"metrics\",\n" +
         "    \"q\": \"sys.cpu.user\"\n" +
@@ -490,8 +490,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testSuggestPostWithValidTypeAndQueryAndMax() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{\n" +
         "    \"type\": \"metrics\",\n" +
         "    \"q\": \"sys.cpu.user\",\n" +
@@ -616,7 +616,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testQueryEmptyTags() throws Exception {
-        // @formatter:off
+    // @formatter:off
         String content =
                 "{\n"+
                         "    \"start\": 1356998400,\n"+
@@ -665,7 +665,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testQueryPostAll() throws Exception {
-        // @formatter:off
+    // @formatter:off
         String content =
         "{\n"+
         "    \"start\": 1356998400,\n"+
@@ -762,7 +762,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testQueryPostGlobalAnnotations() throws Exception {
-        // @formatter:off
+    // @formatter:off
         String content = "" +
         "{"
         + "\"start\":1447767369171,"
@@ -803,8 +803,8 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testQueryPostRateOption() throws Exception {
-        // @formatter:off
-        String content = 
+    // @formatter:off
+        String content =
         "{"
         +  "\"start\":1447767369171,"
         +  "\"queries\":"
@@ -861,7 +861,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testPutMetricPost() throws Exception {
-        // @formatter:off
+    // @formatter:off
         Metric m = Metric.newBuilder()
                 .name("sys.cpu.user")
                 .value(TEST_TIME, 1.0D)

--- a/server/src/test/java/timely/netty/http/login/BasicAuthLoginRequestHandlerTest.java
+++ b/server/src/test/java/timely/netty/http/login/BasicAuthLoginRequestHandlerTest.java
@@ -8,7 +8,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -66,12 +66,12 @@ public class BasicAuthLoginRequestHandlerTest {
         Configuration config = TestConfiguration.createMinimalConfigurationForTest();
 
         // @formatter:off
-		String form = 
+        String form = 
         "{\n" +
-		"    \"username\": \"test\",\n" +
+        "    \"username\": \"test\",\n" +
         "    \"password\": \"test1\"\n" +
-		"}";
-		// @formatter:on
+        "}";
+        // @formatter:on
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/login");
         request.content().writeBytes(form.getBytes());
 
@@ -87,11 +87,11 @@ public class BasicAuthLoginRequestHandlerTest {
         Assert.assertNotNull(ctx.msg);
         Assert.assertTrue(ctx.msg instanceof DefaultFullHttpResponse);
         DefaultFullHttpResponse response = (DefaultFullHttpResponse) ctx.msg;
-        Assert.assertEquals(HttpResponseStatus.OK, response.getStatus());
-        Assert.assertTrue(response.headers().contains(Names.CONTENT_TYPE));
-        Assert.assertEquals(Constants.JSON_TYPE, response.headers().get(Names.CONTENT_TYPE));
-        Assert.assertTrue(response.headers().contains(Names.SET_COOKIE));
-        Cookie c = ClientCookieDecoder.STRICT.decode(response.headers().get(Names.SET_COOKIE));
+        Assert.assertEquals(HttpResponseStatus.OK, response.status());
+        Assert.assertTrue(response.headers().contains(HttpHeaderNames.CONTENT_TYPE));
+        Assert.assertEquals(Constants.JSON_TYPE, response.headers().get(HttpHeaderNames.CONTENT_TYPE));
+        Assert.assertTrue(response.headers().contains(HttpHeaderNames.SET_COOKIE));
+        Cookie c = ClientCookieDecoder.STRICT.decode(response.headers().get(HttpHeaderNames.SET_COOKIE));
         Assert.assertEquals(TestConfiguration.TIMELY_HTTP_ADDRESS_DEFAULT, c.domain());
         Assert.assertEquals(86400, c.maxAge());
         Assert.assertTrue(c.isHttpOnly());
@@ -105,12 +105,12 @@ public class BasicAuthLoginRequestHandlerTest {
         Configuration config = TestConfiguration.createMinimalConfigurationForTest();
 
         // @formatter:off
-		String form = 
+        String form = 
         "{\n" +
-		"    \"username\": \"test\",\n" +
+        "    \"username\": \"test\",\n" +
         "    \"password\": \"test2\"\n" +
-		"}";
-		// @formatter:on
+        "}";
+        // @formatter:on
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/login");
         request.content().writeBytes(form.getBytes());
 
@@ -126,9 +126,9 @@ public class BasicAuthLoginRequestHandlerTest {
         Assert.assertNotNull(ctx.msg);
         Assert.assertTrue(ctx.msg instanceof DefaultFullHttpResponse);
         DefaultFullHttpResponse response = (DefaultFullHttpResponse) ctx.msg;
-        Assert.assertEquals(HttpResponseStatus.UNAUTHORIZED, response.getStatus());
-        Assert.assertTrue(response.headers().contains(Names.CONTENT_TYPE));
-        Assert.assertEquals(Constants.JSON_TYPE, response.headers().get(Names.CONTENT_TYPE));
+        Assert.assertEquals(HttpResponseStatus.UNAUTHORIZED, response.status());
+        Assert.assertTrue(response.headers().contains(HttpHeaderNames.CONTENT_TYPE));
+        Assert.assertEquals(Constants.JSON_TYPE, response.headers().get(HttpHeaderNames.CONTENT_TYPE));
     }
 
 }

--- a/server/src/test/java/timely/netty/websocket/WebSocketRequestDecoderTest.java
+++ b/server/src/test/java/timely/netty/websocket/WebSocketRequestDecoderTest.java
@@ -15,7 +15,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import timely.api.request.MetricRequest;
 import timely.api.request.VersionRequest;
 import timely.api.request.subscription.AddSubscription;
@@ -65,7 +64,6 @@ public class WebSocketRequestDecoderTest {
         anonConfig.getSecurity().setAllowAnonymousWsAccess(true);
         cookie = URLEncoder.encode(UUID.randomUUID().toString(), StandardCharsets.UTF_8.name());
         AuthCache.configure(config.getSecurity());
-        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken("test", "test1");
         AuthCache.put(cookie, new TimelyPrincipal(TimelyUser.ANONYMOUS_USER));
     }
 
@@ -83,7 +81,7 @@ public class WebSocketRequestDecoderTest {
     @Test
     public void testVersion() throws Exception {
         decoder = new WebSocketRequestDecoder(anonConfig.getSecurity());
-        // @formatter:off
+    // @formatter:off
         String request = "{ "+
           "\"operation\" : \"version\"" +
         " }";
@@ -98,19 +96,19 @@ public class WebSocketRequestDecoderTest {
     @Test
     public void testPutMetric() throws Exception {
         decoder = new WebSocketRequestDecoder(anonConfig.getSecurity());
-        // @formatter:off
-        String request = "{" + 
-          "\"operation\" : \"put\",\n" + 
+    // @formatter:off
+        String request = "{" +
+          "\"operation\" : \"put\",\n" +
           "\"name\" : \"sys.cpu.user\",\n" +
-          "\"timestamp\":" + TEST_TIME + ",\n" + 
+          "\"timestamp\":" + TEST_TIME + ",\n" +
           "\"measure\":1.0,\n" +
-          "\"tags\":[ {\n" + 
-              "\"key\":\"tag1\",\n" + 
-              "\"value\":\"value1\"\n" + 
-          "},{\n" + 
-              "\"key\":\"tag2\",\n" + 
+          "\"tags\":[ {\n" +
+              "\"key\":\"tag1\",\n" +
+              "\"value\":\"value1\"\n" +
+          "},{\n" +
+              "\"key\":\"tag2\",\n" +
               "\"value\":\"value2\"\n" +
-          "}]\n" + 
+          "}]\n" +
         "}";
         // @formatter:on
         TextWebSocketFrame frame = new TextWebSocketFrame();
@@ -128,10 +126,10 @@ public class WebSocketRequestDecoderTest {
     @Test
     public void testCreateSubscriptionWithMissingSessionId() throws Exception {
         decoder = new WebSocketRequestDecoder(config.getSecurity());
-        // @formatter:off
-        String request = "{ "+ 
+    // @formatter:off
+        String request = "{ "+
           "\"operation\" : \"create\", " +
-          "\"subscriptionId\" : \"1234\"" + 
+          "\"subscriptionId\" : \"1234\"" +
         " }";
         // @formatter:on
         TextWebSocketFrame frame = new TextWebSocketFrame();
@@ -148,10 +146,10 @@ public class WebSocketRequestDecoderTest {
         ctx.channel().attr(SubscriptionRegistry.SESSION_ID_ATTR)
                 .set(URLEncoder.encode(UUID.randomUUID().toString(), StandardCharsets.UTF_8.name()));
         decoder = new WebSocketRequestDecoder(config.getSecurity());
-        // @formatter:off
-        String request = "{ "+ 
+    // @formatter:off
+        String request = "{ "+
           "\"operation\" : \"create\", " +
-          "\"subscriptionId\" : \"1234\"" + 
+          "\"subscriptionId\" : \"1234\"" +
         " }";
         // @formatter:on
         TextWebSocketFrame frame = new TextWebSocketFrame();
@@ -167,9 +165,9 @@ public class WebSocketRequestDecoderTest {
     public void testCreateSubscriptionWithValidSessionIdAndNonAnonymousAccess() throws Exception {
         ctx.channel().attr(SubscriptionRegistry.SESSION_ID_ATTR).set(cookie);
         decoder = new WebSocketRequestDecoder(config.getSecurity());
-        // @formatter:off
-        String request = "{ " + 
-          "\"operation\" : \"create\"," + 
+    // @formatter:off
+        String request = "{ " +
+          "\"operation\" : \"create\"," +
           "\"subscriptionId\" : \"" + cookie + "\"" +
         "}";
         // @formatter:on
@@ -276,7 +274,7 @@ public class WebSocketRequestDecoderTest {
         // @formatter:off
         String request =
         "{\n"+
-        "	 \"operation\" : \"query\",\n"+
+        "     \"operation\" : \"query\",\n"+
         "    \"sessionId\" : \"1234\",\n"+
         "    \"start\": 1356998400,\n"+
         "    \"end\": 1356998460,\n"+
@@ -343,15 +341,15 @@ public class WebSocketRequestDecoderTest {
     @Test
     public void testSuggest() throws Exception {
         // @formatter:off
-    	String request = 
-    			"{\n" +
-    			"    \"operation\" : \"suggest\",\n" +
-    	        "    \"sessionId\" : \"1234\",\n" +
-    	        "    \"type\": \"metrics\",\n" +
-    	        "    \"q\": \"sys.cpu.user\",\n" +
-    	        "    \"max\": 30\n" +    			
-    			"}";
-    	// @formatter:on
+        String request =
+                "{\n" +
+                "    \"operation\" : \"suggest\",\n" +
+                "    \"sessionId\" : \"1234\",\n" +
+                "    \"type\": \"metrics\",\n" +
+                "    \"q\": \"sys.cpu.user\",\n" +
+                "    \"max\": 30\n" +
+                "}";
+        // @formatter:on
         decoder = new WebSocketRequestDecoder(anonConfig.getSecurity());
         TextWebSocketFrame frame = new TextWebSocketFrame();
         frame.content().writeBytes(request.getBytes(StandardCharsets.UTF_8));

--- a/server/src/test/java/timely/sample/iterators/AggregationIteratorTest.java
+++ b/server/src/test/java/timely/sample/iterators/AggregationIteratorTest.java
@@ -55,11 +55,6 @@ public class AggregationIteratorTest {
     /**
      * This will add key, values to the test data as output from the
      * DownsampleIterator
-     * 
-     * @param testData
-     * @param m
-     * @param sample
-     * @throws Exception
      */
     void put(Map<Key, Value> testData, Metric m, Downsample sample) throws Exception {
         Mutation mutation = MetricAdapter.toMutation(m);

--- a/server/src/test/java/timely/store/MetaAgeOffIteratorTest.java
+++ b/server/src/test/java/timely/store/MetaAgeOffIteratorTest.java
@@ -21,7 +21,6 @@ public class MetaAgeOffIteratorTest {
 
     private static final Long TEST_TIME = System.currentTimeMillis() - 1000;
     private static final Integer ONE_DAY = 86400000;
-    private static final Value EMPTY_VALUE = new Value(new byte[0]);
     private static final Collection<ByteSequence> columnFamilies = new ArrayList<>();
 
     @Test(expected = IllegalArgumentException.class)

--- a/server/src/test/java/timely/store/cache/TestDataStoreCacheIterator.java
+++ b/server/src/test/java/timely/store/cache/TestDataStoreCacheIterator.java
@@ -165,7 +165,6 @@ public class TestDataStoreCacheIterator {
         subQuery.setRateOptions(rateOption);
         query.setQueries(Collections.singleton(subQuery));
 
-        int x = 0;
         SortedKeyValueIterator<org.apache.accumulo.core.data.Key, org.apache.accumulo.core.data.Value> itr = null;
         try {
             // long firstTimestamp = Long.MAX_VALUE;

--- a/server/src/test/java/timely/store/cache/TestGorillaStore.java
+++ b/server/src/test/java/timely/store/cache/TestGorillaStore.java
@@ -1,15 +1,13 @@
 package timely.store.cache;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
 
 import fi.iki.yak.ts.compression.gorilla.Pair;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import timely.configuration.Configuration;
-import timely.model.Metric;
-import timely.model.Tag;
-import timely.model.Value;
 
 public class TestGorillaStore {
 
@@ -57,21 +55,6 @@ public class TestGorillaStore {
         }
     }
 
-    private Metric createMetric(String metric, Map<String, String> tags, double value, long timestamp) {
-        Metric m = new Metric();
-        m.setName(metric);
-        List<Tag> tagList = new ArrayList<>();
-        for (Map.Entry<String, String> entry : tags.entrySet()) {
-            tagList.add(new Tag(entry.getKey(), entry.getValue()));
-        }
-        m.setTags(tagList);
-        Value metricValue = new Value();
-        metricValue.setMeasure(value);
-        metricValue.setTimestamp(timestamp);
-        m.setValue(metricValue);
-        return m;
-    }
-
     @Test
     public void testExtentOfStorage() {
 
@@ -100,12 +83,9 @@ public class TestGorillaStore {
             long totalObservations = 0;
 
             List<WrappedGorillaDecompressor> decompressorList = gStore.getDecompressors(start, timestamp);
-            Pair pair = null;
             for (WrappedGorillaDecompressor w : decompressorList) {
-                while ((pair = w.readPair()) != null) {
+                while (w.readPair() != null) {
                     totalObservations++;
-                    // System.out.println(pair.getTimestamp() + " --> " +
-                    // pair.getDoubleValue());
                 }
             }
 

--- a/server/src/test/java/timely/test/CaptureChannelHandlerContext.java
+++ b/server/src/test/java/timely/test/CaptureChannelHandlerContext.java
@@ -36,11 +36,13 @@ public class CaptureChannelHandlerContext implements ChannelHandlerContext {
     public Object msg = null;
     private TestDefaultPromise promise = new TestDefaultPromise(null);
 
+    @Deprecated
     @Override
     public <T> Attribute<T> attr(AttributeKey<T> key) {
         return null;
     }
 
+    @Deprecated
     @Override
     public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
         return false;

--- a/server/src/test/java/timely/test/integration/OneWaySSLBase.java
+++ b/server/src/test/java/timely/test/integration/OneWaySSLBase.java
@@ -7,7 +7,11 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
-import io.netty.handler.ssl.*;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,7 +22,6 @@ import timely.configuration.Configuration;
 /**
  * Base test class for SSL with anonymous access
  */
-@SuppressWarnings("deprecation")
 public class OneWaySSLBase extends QueryBase {
 
     protected static File clientTrustStoreFile = null;
@@ -29,7 +32,8 @@ public class OneWaySSLBase extends QueryBase {
         builder.sslProvider(SslProvider.JDK);
         builder.trustManager(clientTrustStoreFile); // Trust the server cert
         SslContext ctx = builder.build();
-        Assert.assertEquals(JdkSslClientContext.class, ctx.getClass());
+        Assert.assertTrue(ctx.isClient());
+        Assert.assertTrue(ctx instanceof JdkSslContext);
         JdkSslContext jdk = (JdkSslContext) ctx;
         SSLContext jdkSslContext = jdk.context();
         return jdkSslContext.getSocketFactory();
@@ -56,6 +60,7 @@ public class OneWaySSLBase extends QueryBase {
         return getUrlConnection(url);
     }
 
+    @Override
     protected HttpsURLConnection getUrlConnection(URL url) throws Exception {
         HttpsURLConnection.setDefaultSSLSocketFactory(getSSLSocketFactory());
         HttpsURLConnection con = (HttpsURLConnection) url.openConnection();

--- a/server/src/test/java/timely/test/integration/OneWaySSLBasicAuthAccessIT.java
+++ b/server/src/test/java/timely/test/integration/OneWaySSLBasicAuthAccessIT.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import org.apache.accumulo.core.client.Connector;
@@ -68,12 +68,12 @@ public class OneWaySSLBasicAuthAccessIT extends OneWaySSLBase {
             throw new UnauthorizedUserException();
         }
         Assert.assertEquals(200, responseCode);
-        List<String> cookies = con.getHeaderFields().get(Names.SET_COOKIE);
+        List<String> cookies = con.getHeaderFields().get(HttpHeaderNames.SET_COOKIE.toString());
         Assert.assertEquals(1, cookies.size());
         Cookie sessionCookie = ClientCookieDecoder.STRICT.decode(cookies.get(0));
         Assert.assertEquals(Constants.COOKIE_NAME, sessionCookie.name());
         con = (HttpsURLConnection) url.openConnection();
-        con.setRequestProperty(Names.COOKIE, sessionCookie.name() + "=" + sessionCookie.value());
+        con.setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie.name() + "=" + sessionCookie.value());
         con.setHostnameVerifier((host, session) -> true);
         return con;
     }

--- a/server/src/test/java/timely/test/integration/QueryBase.java
+++ b/server/src/test/java/timely/test/integration/QueryBase.java
@@ -12,7 +12,7 @@ import java.util.List;
 import javax.net.ssl.HttpsURLConnection;
 
 import com.fasterxml.jackson.databind.JavaType;
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ public abstract class QueryBase extends MacITBase {
         HttpsURLConnection con = getUrlConnection(url);
         if (null != acceptType) {
             LOG.trace("Setting Accept header to {}", acceptType);
-            con.addRequestProperty(Names.ACCEPT, acceptType);
+            con.addRequestProperty(HttpHeaderNames.ACCEPT.toString(), acceptType);
         }
         LOG.trace("Sending HTTP Headers: {}", con.getRequestProperties());
         int responseCode = con.getResponseCode();

--- a/server/src/test/java/timely/test/integration/client/TcpClientIT.java
+++ b/server/src/test/java/timely/test/integration/client/TcpClientIT.java
@@ -84,9 +84,9 @@ public class TcpClientIT extends OneWaySSLBase {
         try (TcpClient client = new TcpClient("127.0.0.1", 54321)) {
             client.open();
             // @formatter:off
-        	client.write("put sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2\n"
+            client.write("put sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2\n"
                        + "put sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4\n");
-        	client.flush();
+            client.flush();
             while (2 != m.getTcpRequests().getCount()) {
                 Thread.sleep(5);
             }

--- a/server/src/test/java/timely/test/integration/client/WebSocketClientIT.java
+++ b/server/src/test/java/timely/test/integration/client/WebSocketClientIT.java
@@ -14,7 +14,6 @@ import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 
 import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.JdkSslClientContext;
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -39,7 +38,6 @@ import timely.test.IntegrationTest;
 import timely.test.TestConfiguration;
 import timely.test.integration.OneWaySSLBase;
 
-@SuppressWarnings("deprecation")
 @Category(IntegrationTest.class)
 public class WebSocketClientIT extends OneWaySSLBase {
 
@@ -56,7 +54,8 @@ public class WebSocketClientIT extends OneWaySSLBase {
         builder.sslProvider(SslProvider.JDK);
         builder.trustManager(clientTrustStoreFile); // Trust the server cert
         SslContext ctx = builder.build();
-        Assert.assertEquals(JdkSslClientContext.class, ctx.getClass());
+        Assert.assertTrue(ctx.isClient());
+        Assert.assertTrue(ctx instanceof JdkSslContext);
         JdkSslContext jdk = (JdkSslContext) ctx;
         sslCtx = jdk.context();
     }
@@ -70,6 +69,7 @@ public class WebSocketClientIT extends OneWaySSLBase {
         setupSslCtx();
     }
 
+    @Override
     @After
     public void tearDown() throws Exception {
         s.shutdown();
@@ -80,10 +80,10 @@ public class WebSocketClientIT extends OneWaySSLBase {
         // Add some data
         // @formatter:off
         put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
-        	"sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2", 
-        	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1", 
-        	"sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
-		// @formatter:on
+            "sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
+            "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+            "sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+        // @formatter:on
 
         // Latency in TestConfiguration is 2s, wait for it
         sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);

--- a/server/src/test/java/timely/test/integration/http/HTTPStrictTransportSecurityIT.java
+++ b/server/src/test/java/timely/test/integration/http/HTTPStrictTransportSecurityIT.java
@@ -7,7 +7,7 @@ import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 import timely.Server;
@@ -39,7 +39,7 @@ public class HTTPStrictTransportSecurityIT extends OneWaySSLBase {
         con.setRequestMethod("GET");
         int responseCode = con.getResponseCode();
         assertEquals(301, responseCode);
-        assertEquals("https://localhost:54322/secure-me", con.getHeaderField(Names.LOCATION));
+        assertEquals("https://localhost:54322/secure-me", con.getHeaderField(HttpHeaderNames.LOCATION.toString()));
         con.disconnect();
     }
 

--- a/server/src/test/java/timely/test/integration/http/HttpApiIT.java
+++ b/server/src/test/java/timely/test/integration/http/HttpApiIT.java
@@ -93,7 +93,7 @@ public class HttpApiIT extends OneWaySSLBase {
         final Server s = new Server(conf);
         s.run();
         try {
-            // @formatter:off
+      // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2",
                 "sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4",
                 "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 viz=(a|b|c)",
@@ -122,9 +122,8 @@ public class HttpApiIT extends OneWaySSLBase {
 
     @Test
     public void testMetricsJson() throws Exception {
-        // @formatter:off
+    // @formatter:off
 
-        String expected = "{\"metrics\":[{\"metric\":\"sys.cpu.user\",\"tags\":[{\"key\":\"tag2\",\"value\":\"value2\"},{\"key\":\"tag1\",\"value\":\"value1\"}]},{\"metric\":\"sys.cpu.idle\",\"tags\":[{\"key\":\"tag4\",\"value\":\"value4\"},{\"key\":\"tag3\",\"value\":\"value3\"}]},{\"metric\":\"zzzz\",\"tags\":[{\"key\":\"host\",\"value\":\"localhost\"}]}]}";
         final Server s = new Server(conf);
         s.run();
         try {
@@ -406,7 +405,7 @@ public class HttpApiIT extends OneWaySSLBase {
     public void testQueryWithTagWildcard() throws Exception {
         final Server s = new Server(conf);
         s.run();
-        // @formatter:off
+    // @formatter:off
         try {
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME + 1) + " 1.0 tag3=value3 rack=r2",
@@ -471,7 +470,7 @@ public class HttpApiIT extends OneWaySSLBase {
     public void testQueryWithTagWildcard2() throws Exception {
         final Server s = new Server(conf);
         s.run();
-        // @formatter:off
+    // @formatter:off
         try {
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME + 1) + " 1.0 tag3=value3 rack=r2",
@@ -532,7 +531,7 @@ public class HttpApiIT extends OneWaySSLBase {
         final Server s = new Server(conf);
         s.run();
         try {
-            // @formatter:off
+      // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME + 1L) + " 1.0 tag3=value3 rack=r2",
                     "sys.cpu.idle " + (TEST_TIME + 2L) + " 2.0 tag3=value3 tag4=value4 rack=r1",
@@ -570,14 +569,14 @@ public class HttpApiIT extends OneWaySSLBase {
                            switch(tagv){
                                case "r1":
                                    assertEquals(2.0D, measure, 0.0);
-                                   assertEquals("TEST_TIME: " + getBaselineStart(TEST_TIME + 2), 
-                                		   getBaselineStart(TEST_TIME + 2), ts.toString());
+                                   assertEquals("TEST_TIME: " + getBaselineStart(TEST_TIME + 2),
+                                           getBaselineStart(TEST_TIME + 2), ts.toString());
                                    rack1Count.getAndIncrement();
                                    break;
                                case "r2":
                                    assertEquals(3.0D, measure, 0.0);
-                                   assertEquals("TEST_TIME: " + getBaselineStart(TEST_TIME + 1000), 
-                                		   getBaselineStart(TEST_TIME + 1000), ts.toString());
+                                   assertEquals("TEST_TIME: " + getBaselineStart(TEST_TIME + 1000),
+                                           getBaselineStart(TEST_TIME + 1000), ts.toString());
                                    rack2Count.getAndIncrement();
                                    break;
                                default:
@@ -739,22 +738,22 @@ public class HttpApiIT extends OneWaySSLBase {
         s.run();
         try {
             // @formatter:off
-            put("sys.cpu.user " + (TEST_TIME) + " 1.0 tag1=value1 tag2=value2 rack=r1", 
-            	"sys.cpu.user " + (TEST_TIME+1) + " 2.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+2) + " 3.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+3) + " 4.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+4) + " 5.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+5) + " 6.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+6) + " 7.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+7) + " 8.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+8) + " 9.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+9) + " 10.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+10) + " 11.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+11) + " 12.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+12) + " 13.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+13) + " 14.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME+14) + " 15.0 tag1=value1 tag2=value2 rack=r1");
-    		// @formatter:on
+            put("sys.cpu.user " + (TEST_TIME) + " 1.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+1) + " 2.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+2) + " 3.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+3) + " 4.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+4) + " 5.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+5) + " 6.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+6) + " 7.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+7) + " 8.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+8) + " 9.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+9) + " 10.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+10) + " 11.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+11) + " 12.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+12) + " 13.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+13) + " 14.0 tag1=value1 tag2=value2 rack=r1",
+                "sys.cpu.user " + (TEST_TIME+14) + " 15.0 tag1=value1 tag2=value2 rack=r1");
+            // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
             QueryRequest request = new QueryRequest();
@@ -790,7 +789,7 @@ public class HttpApiIT extends OneWaySSLBase {
         final Server s = new Server(conf);
         s.run();
         try {
-            // @formatter:off
+      // @formatter:off
             put("sys.cpu.user " + (TEST_TIME) + " 1.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME+1) + " 2.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME+2) + " 3.0 tag1=value1 tag2=value2 rack=r1",
@@ -844,7 +843,7 @@ public class HttpApiIT extends OneWaySSLBase {
         final Server s = new Server(conf);
         s.run();
         try {
-            // @formatter:off
+      // @formatter:off
             put("sys.cpu.user " + (TEST_TIME) + " 1.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME+1) + " 2.0 tag1=value1 tag2=value2 rack=r1",
                     "sys.cpu.user " + (TEST_TIME+2) + " 3.0 tag1=value1 tag2=value2 rack=r1",

--- a/server/src/test/java/timely/test/integration/websocket/WebSocketIT.java
+++ b/server/src/test/java/timely/test/integration/websocket/WebSocketIT.java
@@ -25,8 +25,8 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpHeaders.Names;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
@@ -201,7 +201,7 @@ public class WebSocketIT extends OneWaySSLBase {
 
         String cookieVal = ClientCookieEncoder.STRICT.encode(Constants.COOKIE_NAME, sessionId);
         HttpHeaders headers = new DefaultHttpHeaders();
-        headers.add(Names.COOKIE, cookieVal);
+        headers.add(HttpHeaderNames.COOKIE, cookieVal);
 
         WebSocketClientHandshaker handshaker = WebSocketClientHandshakerFactory.newHandshaker(LOCATION,
                 WebSocketVersion.V13, (String) null, false, headers);
@@ -236,9 +236,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some data
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+                "sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -287,9 +287,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some data
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+                "sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -324,9 +324,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some more data
             // @formatter:off
             put("sys.cpu.user " + (TEST_TIME + 500) + " 6.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+                "sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -429,9 +429,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some data
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+                "sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -467,9 +467,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some more data
             // @formatter:off
             put("sys.cpu.user " + (TEST_TIME + 500) + " 6.0 tag1=value1 tag2=value2 rack=r1",
-            	"sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2");
+                "sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -516,9 +516,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some data
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2 rack=r1 viz=A",
-            	"sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2 viz=A",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1 viz=A",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2 viz=A");
+                "sys.cpu.user " + TEST_TIME + " 1.0 tag3=value3 rack=r2 viz=A",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4 rack=r1 viz=A",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 3.0 tag3=value3 tag4=value4 rack=r2 viz=A");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -555,9 +555,9 @@ public class WebSocketIT extends OneWaySSLBase {
             // Add some more data
             // @formatter:off
             put("sys.cpu.user " + (TEST_TIME + 500) + " 6.0 tag1=value1 tag2=value2 rack=r1, viz=A",
-            	"sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2, viz=A",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1, viz=A",
-            	"sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2, viz=A");
+                "sys.cpu.user " + (TEST_TIME + 500) + " 7.0 tag3=value3 rack=r2, viz=A",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 1.0 tag3=value3 tag4=value4 rack=r1, viz=A",
+                "sys.cpu.idle " + (TEST_TIME + 1000) + " 3.0 tag3=value3 tag4=value4 rack=r2, viz=A");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -641,8 +641,8 @@ public class WebSocketIT extends OneWaySSLBase {
         try {
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2",
-            	"sys.cpu.user " + (TEST_TIME + 1000) + " 3.0 tag1=value1 tag2=value2",
-            	"sys.cpu.user " + (TEST_TIME + 2000) + " 2.0 tag1=value1 tag3=value3 viz=secret");
+                "sys.cpu.user " + (TEST_TIME + 1000) + " 3.0 tag1=value1 tag2=value2",
+                "sys.cpu.user " + (TEST_TIME + 2000) + " 2.0 tag1=value1 tag3=value3 viz=secret");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
@@ -705,22 +705,22 @@ public class WebSocketIT extends OneWaySSLBase {
         try {
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2",
-            	"sys.cpu.user " + (TEST_TIME + 1) + " 1.0 tag3=value3",
-            	"sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4",
+                "sys.cpu.user " + (TEST_TIME + 1) + " 1.0 tag3=value3",
+                "sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4",
                 "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4");
             // @formatter:on
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
 
             // @formatter:off
-            String request = 
+            String request =
             "{"+
             "   \"operation\" : \"lookup\","+
             "   \"metric\" : \"sys.cpu.idle\","+
             "   \"tags\" : ["+
                    "\"tag3=.*\""+
                 "]"+
-    	    "}";
+            "}";
             // @formatter:on
             ch.writeAndFlush(new TextWebSocketFrame(request));
 
@@ -750,22 +750,22 @@ public class WebSocketIT extends OneWaySSLBase {
         try {
             // @formatter:off
             put("sys.cpu.user " + TEST_TIME + " 1.0 tag1=value1 tag2=value2",
-            	"sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4",
-            	"sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4",
-            	"zzzz 1234567892 1.0 host=localhost");
+                "sys.cpu.idle " + (TEST_TIME + 1) + " 1.0 tag3=value3 tag4=value4",
+                "sys.cpu.idle " + (TEST_TIME + 2) + " 1.0 tag3=value3 tag4=value4",
+                "zzzz 1234567892 1.0 host=localhost");
             // @formatter:off
             // Latency in TestConfiguration is 2s, wait for it
             sleepUninterruptibly(TestConfiguration.WAIT_SECONDS, TimeUnit.SECONDS);
 
             // @formatter:off
-        	String request = 
-        			"{\n" +
-        			"    \"operation\" : \"suggest\",\n" +
-        	        "    \"type\": \"metrics\",\n" +
-        	        "    \"q\": \"sys.cpu.user\",\n" +
-        	        "    \"max\": 30\n" +    			
-        			"}";
-        	// @formatter:on
+            String request =
+                    "{\n" +
+                    "    \"operation\" : \"suggest\",\n" +
+                    "    \"type\": \"metrics\",\n" +
+                    "    \"q\": \"sys.cpu.user\",\n" +
+                    "    \"max\": 30\n" +
+                    "}";
+            // @formatter:on
             ch.writeAndFlush(new TextWebSocketFrame(request));
 
             // Confirm receipt of all data sent to this point

--- a/server/src/test/resources/log4j2.xml
+++ b/server/src/test/resources/log4j2.xml
@@ -11,7 +11,7 @@
     <Logger name="org.apache.zookeeper" level="OFF" additivity="false" />
 <!--     <Logger name="javax.net.debug" level="ALL" additivity="false"/> -->
 <!--     <Logger name="sun.net.www.protocol.http.HttpURLConnection" level="ALL" additivity="false" /> -->
-    <Root level="TRACE">
+    <Root level="WARN">
       <AppenderRef ref="CONSOLE"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
Build:
* Fix netty-tcnative-boringssl-static version specs in pom.xml
* Bump the version of accumulo to latest release (1.9.3)
* Update jackson to 2.9.9 (CVE-2019-12086)

Warnings:
* Remove all use of deprecated netty stuffs and use their replacements
  in the netty APIs
* Add missing generics parameters everywhere
* Remove unused code (unused private fields, such as loggers)
* Remove standard javadoc tags that were missing descriptions (these do
  not add value to the javadocs, since default `@param`, `@throws`, and
  `@return` tags are provided by javadoc)
* Add missing serialVersionUid fields to Serializable classes
* Fix a resource leak warning about not closing ScannerOptionsHelper
  (NOTE: 3 other resource leak warnings exist, but did not attempt to
  fix those, since they were non-trivial)
* Remove deprecated annotations from hibernate and replace with their
  non-deprecated counterparts from javax.validation.constraints
* Remove use of deprecated Accumulo ClientConfiguration constructor

Other:
* Use lowercase header names, for HTTP/2 compatibility (and to stop
  incorrectly assuming case-sensitivity for HTTP/1)
* Narrow the scope of necessary `@SuppressWarnings("unchecked")`
  occurrences to a variable instead of suppressing for an entire method or
  an entire class
* IDE added some missing overrides annotations
* (style consistency) Replace tabs with spaces
* Set log4j2 root logger level for tests to WARN instead of TRACE