### PR TITLE
Fixes #184 Metric compaction strategy and summary implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <version.commons-pool2>2.6.1</version.commons-pool2>
     <version.curator>4.1.0</version.curator>
     <version.disruptor>3.4.2</version.disruptor>
+    <version.easymock>4.0.2</version.easymock>
     <version.eclipse-lifecycle>1.0.0</version.eclipse-lifecycle>
     <version.fast-classpath-scanner>3.1.13</version.fast-classpath-scanner>
     <version.flink>1.1.4</version.flink>
@@ -394,6 +395,12 @@
         <groupId>net.jcip</groupId>
         <artifactId>jcip-annotations</artifactId>
         <version>${version.jcip-annotations}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>${version.easymock}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/server/bin/get-tablet-summary.sh
+++ b/server/bin/get-tablet-summary.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ `uname` == "Darwin" ]]; then
+        THIS_SCRIPT=`python -c 'import os,sys; print os.path.realpath(sys.argv[1])' $0`
+else
+        THIS_SCRIPT=`readlink -f $0`
+fi
+
+THIS_DIR="${THIS_SCRIPT%/*}"
+BASE_DIR=${THIS_DIR}/..
+CONF_DIR="${BASE_DIR}/conf"
+LIB_DIR="${BASE_DIR}/lib"
+
+export CLASSPATH="${CONF_DIR}:${LIB_DIR}/*"
+JVM_ARGS="-Xmx1024m -Xms128m"
+JVM_ARGS="${JVM_ARGS} -Dlogging.config=${CONF_DIR}/log4j2-error-console.xml"
+JVM_ARGS="${JVM_ARGS} -Dlog4j.configurationFile=${CONF_DIR}/log4j2-error-console.xml"
+JVM_ARGS="${JVM_ARGS} -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
+
+echo "$JAVA_HOME/bin/java ${JVM_ARGS} timely.store.compaction.util.TabletMetadataConsole --spring.config.name=timely"
+$JAVA_HOME/bin/java ${JVM_ARGS} timely.store.compaction.util.TabletMetadataConsole --spring.config.name=timely

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -178,8 +178,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-easymock-release-full</artifactId>
+      <classifier>full</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/server/src/main/java/timely/store/compaction/MetricCompactionStrategy.java
+++ b/server/src/main/java/timely/store/compaction/MetricCompactionStrategy.java
@@ -1,0 +1,188 @@
+package timely.store.compaction;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.server.fs.FileRef;
+import org.apache.accumulo.tserver.compaction.CompactionPlan;
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
+import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import timely.store.MetricAgeOffIterator;
+
+public class MetricCompactionStrategy extends CompactionStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricCompactionStrategy.class);
+
+    private boolean hasMinAgeOff;
+    private MetricAgeOffConfiguration minAgeOffConfig;
+    private boolean logOnly;
+    private String filterPrefix;
+    private String majcIteratorName;
+    private long explicitTimeMillis;
+    private boolean useExplicitTime;
+
+    public static final String LOG_ONLY_KEY = "logonly";
+    public static final String MAJC_ITERATOR_NAME_KEY = "majc.name";
+    public static final String DEFAULT_MAJC_ITERATOR_NAME = "ageoffmetrics";
+    public static final String AGE_OFF_PREFIX = MetricAgeOffIterator.AGE_OFF_PREFIX;
+    public static final String FILTER_PREFIX_KEY = AGE_OFF_PREFIX + "filter";
+    public static final String MIN_AGEOFF_KEY = AGE_OFF_PREFIX + "min";
+    public static final String DEFAULT_AGEOFF_KEY_SUFFIX = MetricAgeOffIterator.DEFAULT_AGEOFF_KEY;
+    public static final String DEFAULT_AGEOFF_KEY = AGE_OFF_PREFIX + DEFAULT_AGEOFF_KEY_SUFFIX;
+
+    @Override
+    public void init(Map<String, String> options) {
+        // options:
+        // logonly - disables compaction and will only log result
+        // majciterator - the iterator name to gather age-off values
+        // filter - limit the compaction to just a subset of prefixes
+        // min - minimum age-off which may override the metric age-off;
+        // allows more data to accumulate in tablets without being removed
+
+        logOnly = options.containsKey(LOG_ONLY_KEY) && Boolean.parseBoolean(options.get(LOG_ONLY_KEY));
+        majcIteratorName = options.getOrDefault(MAJC_ITERATOR_NAME_KEY, DEFAULT_MAJC_ITERATOR_NAME);
+        filterPrefix = options.get(FILTER_PREFIX_KEY);
+        if (options.containsKey(MIN_AGEOFF_KEY)) {
+            long minAgeOff = Long.parseLong(options.get(MIN_AGEOFF_KEY));
+            hasMinAgeOff = true;
+            minAgeOffConfig = MetricAgeOffConfiguration.newFromDefaultingMinimum(minAgeOff);
+        }
+    }
+
+    @Override
+    public boolean shouldCompact(MajorCompactionRequest request) {
+        TabletId tabletId = request.getTabletId();
+
+        if (null == tabletId.getEndRow() || null == tabletId.getPrevEndRow()) {
+            return false;
+        } else if (request.getFiles().isEmpty()) {
+            return false;
+        }
+
+        // check if prev/end key are both at age-off intervals
+        // skip tablet if there is no prev-end key, or previous age-off is not at max;
+        // other age-off will compact
+        Optional<String> endName = TabletRowAdapter.decodeRowPrefix(tabletId.getEndRow());
+        OptionalLong endOffset = TabletRowAdapter.decodeRowOffset(tabletId.getEndRow());
+        Optional<String> prevEndName = TabletRowAdapter.decodeRowPrefix(tabletId.getPrevEndRow());
+
+        if (!endName.isPresent() || !prevEndName.isPresent() || !endOffset.isPresent()) {
+            return false;
+        }
+
+        // compute age-off from majc iterator
+        // then maximize on the min-default-ageoff so that the
+        // configuration with largest age-off is used
+        MetricAgeOffConfiguration ageOffConfig = MetricAgeOffConfiguration.newFromRequest(request, majcIteratorName);
+        if (hasMinAgeOff) {
+            ageOffConfig = MetricAgeOffConfiguration.maximizeDefaultAgeOff(ageOffConfig, minAgeOffConfig);
+        }
+
+        long currentTime = useExplicitTime ? explicitTimeMillis : System.currentTimeMillis();
+        long ageOffComputed = currentTime - ageOffConfig.computeAgeOff(endName.get());
+        boolean shouldCompact = (ageOffComputed > endOffset.getAsLong() && endName.equals(prevEndName))
+                && (null == filterPrefix || endName.get().startsWith(filterPrefix));
+
+        if (LOG.isDebugEnabled() && logOnly && shouldCompact) {
+            LOG.debug("Tablet will be metric age-off compacted {threshold: {}, endKey: {}, offset: {}, prevKey: {}}",
+                    ageOffComputed, endName, endOffset.getAsLong(), prevEndName);
+        } else if (LOG.isTraceEnabled()) {
+            LOG.trace("Tablet check metric compaction {threshold: {}, endKey: {}, offset: {}, prevKey: {}, result: {}}",
+                    ageOffComputed, endName, endOffset.getAsLong(), prevEndName, shouldCompact);
+        }
+
+        return shouldCompact && !logOnly;
+    }
+
+    @Override
+    public CompactionPlan getCompactionPlan(MajorCompactionRequest request) {
+        CompactionPlan plan = null;
+        if (shouldCompact(request)) {
+            plan = new CompactionPlan();
+            for (FileRef ref : request.getFiles().keySet()) {
+                plan.inputFiles.add(ref);
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Tablet selected for age-off: " + TabletRowAdapter.toDebugOutput(request.getTabletId()));
+            }
+        }
+
+        return plan;
+    }
+
+    void setExplicitTime(long timeMillis) {
+        explicitTimeMillis = timeMillis;
+        useExplicitTime = true;
+    }
+
+    private static class MetricAgeOffConfiguration {
+
+        private final PatriciaTrie<Long> ageoffs;
+        private final long defaultAgeOff;
+
+        private MetricAgeOffConfiguration(PatriciaTrie<Long> ageoffs, long defaultAgeOff) {
+            this.ageoffs = ageoffs;
+            this.defaultAgeOff = defaultAgeOff;
+        }
+
+        public static MetricAgeOffConfiguration maximizeDefaultAgeOff(MetricAgeOffConfiguration x,
+                MetricAgeOffConfiguration y) {
+            return (x.defaultAgeOff > y.defaultAgeOff) ? x : y;
+        }
+
+        public static MetricAgeOffConfiguration newFromDefaultingMinimum(long minAgeOff) {
+            return new MetricAgeOffConfiguration(new PatriciaTrie<>(), minAgeOff);
+        }
+
+        public static MetricAgeOffConfiguration newFromRequest(MajorCompactionRequest request,
+                String majcIteratorName) {
+            Configuration config = new MapConfiguration(request.getTableProperties());
+            String majcIteratorKey = Property.TABLE_ITERATOR_MAJC_PREFIX.getKey() + majcIteratorName;
+
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Using key lookup for iterator: {}", majcIteratorKey);
+            }
+
+            Configuration configAgeOff = config.subset((majcIteratorKey + ".opt"));
+            if (null == configAgeOff.getString(DEFAULT_AGEOFF_KEY)) {
+                throw new IllegalArgumentException(
+                        DEFAULT_AGEOFF_KEY_SUFFIX + " must be configured for  " + majcIteratorKey);
+            }
+
+            PatriciaTrie<Long> ageoffs = new PatriciaTrie<>();
+            long configureMinAgeOff = Long.MAX_VALUE;
+            long configureMaxAgeOff = Long.MIN_VALUE;
+            Iterator keys = configAgeOff.getKeys();
+            while (keys.hasNext()) {
+                String k = (String) keys.next();
+                String v = configAgeOff.getString(k);
+                if (k.startsWith((AGE_OFF_PREFIX))) {
+                    String name = k.substring(AGE_OFF_PREFIX.length());
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Adding {} to Trie with value {}", name, Long.parseLong(v));
+                    }
+                    long ageoff = Long.parseLong(v);
+                    configureMinAgeOff = Math.min(configureMinAgeOff, ageoff);
+                    configureMaxAgeOff = Math.max(configureMaxAgeOff, ageoff);
+                    ageoffs.put(name, ageoff);
+                }
+            }
+            long defaultAgeOff = ageoffs.get(DEFAULT_AGEOFF_KEY_SUFFIX);
+            return new MetricAgeOffConfiguration(ageoffs, defaultAgeOff);
+        }
+
+        public long computeAgeOff(String metricName) {
+            return ageoffs.getOrDefault(metricName, defaultAgeOff);
+        }
+    }
+}

--- a/server/src/main/java/timely/store/compaction/TabletRowAdapter.java
+++ b/server/src/main/java/timely/store/compaction/TabletRowAdapter.java
@@ -1,0 +1,111 @@
+package timely.store.compaction;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.StringJoiner;
+
+import org.apache.accumulo.core.client.lexicoder.Lexicoder;
+import org.apache.accumulo.core.client.lexicoder.LongLexicoder;
+import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
+import org.apache.accumulo.core.client.lexicoder.impl.ByteUtils;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TabletRowAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TabletRowAdapter.class);
+    private static final Lexicoder<String> PREFIX_DECODER = new StringLexicoder();
+    private static final Lexicoder<Long> OFFSET_DECODER = new LongLexicoder();
+
+    private static final byte DELIMETER = 0x00;
+    private static final int MIN_OFFSET_LEN = 9;
+
+    public static OptionalLong decodeRowOffset(Text row) {
+        OptionalLong offset = OptionalLong.empty();
+        byte[] bytes = row.getBytes();
+        int delimidx = findRowDelimiterIndex(bytes);
+        if (delimidx > 0) {
+            try {
+                byte[] buffer = Arrays.copyOfRange(bytes, delimidx + 1, bytes.length);
+                buffer = ByteUtils.unescape(buffer);
+
+                // key might not have all bytes for long decoding
+                // ensure of sufficient length
+                int extendBy = (MIN_OFFSET_LEN - (buffer.length));
+                if (extendBy > 0) {
+                    buffer = ArrayUtils.addAll(buffer, new byte[extendBy]);
+                }
+
+                long decodedOffset = OFFSET_DECODER.decode(buffer);
+                if (decodedOffset > 0) {
+                    offset = OptionalLong.of(decodedOffset);
+                } else if (LOG.isTraceEnabled()) {
+                    Optional<String> prefix = decodeRowPrefix(row);
+                    LOG.trace(
+                            "Delimiter identified but offset could not parse { prefix: {}, byte-len: {}, "
+                                    + "offset-len: {}, offset-bytes: {}, row-bytes: {} }",
+                            prefix, bytes.length, buffer.length, Hex.encodeHex(buffer), Hex.encodeHex(bytes));
+                }
+            } catch (IllegalArgumentException e) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Unable to parse offset: " + e.getMessage(), e);
+                }
+            }
+        }
+
+        return offset;
+    }
+
+    public static Optional<String> decodeRowPrefix(Text row) {
+        byte[] bytes = row.getBytes();
+        int delimidx = findRowDelimiterIndex(bytes);
+        byte[] prefixBytes = (delimidx >= 0) ? Arrays.copyOfRange(bytes, 0, delimidx) : bytes;
+        Optional<String> tabletName = Optional.empty();
+        try {
+            tabletName = Optional.of(PREFIX_DECODER.decode(ByteUtils.unescape(prefixBytes)));
+        } catch (IllegalArgumentException e) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Unable to parse offset: " + e.getMessage(), e);
+            }
+        }
+
+        return tabletName;
+    }
+
+    public static String toDebugOutput(TabletId tid) {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+        Text endRow = tid.getEndRow();
+        if (null != endRow) {
+            Optional<String> prefix = decodeRowPrefix(endRow);
+            OptionalLong offset = decodeRowOffset(endRow);
+            prefix.ifPresent(s -> joiner.add("prefix: " + s));
+            if (offset.isPresent()) {
+                LocalDateTime date = Instant.ofEpochMilli(offset.getAsLong()).atZone(ZoneId.of("UTC"))
+                        .toLocalDateTime();
+                joiner.add("date: " + date.toString());
+                joiner.add("millis: " + offset.getAsLong());
+            }
+        }
+
+        return joiner.toString();
+    }
+
+    private static int findRowDelimiterIndex(byte[] bytes) {
+        int delimidx = -1;
+        for (int i = bytes.length - 1; i >= 0; i--) {
+            if (bytes[i] == DELIMETER) {
+                delimidx = i;
+                break;
+            }
+        }
+        return delimidx;
+    }
+}

--- a/server/src/main/java/timely/store/compaction/TieredCompactionStrategy.java
+++ b/server/src/main/java/timely/store/compaction/TieredCompactionStrategy.java
@@ -1,0 +1,158 @@
+package timely.store.compaction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
+import org.apache.accumulo.tserver.compaction.CompactionPlan;
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TieredCompactionStrategy extends CompactionStrategy {
+
+    public static final String TIERED_PREFIX = "tier.";
+    public static final String TIERED_CLASS = "class";
+    public static final String TIERED_OPTS = "opts";
+
+    protected final Collection<TieredCompactorSupplier> compactors;
+
+    public TieredCompactionStrategy() {
+        compactors = new ArrayList<>();
+    }
+
+    public Collection<TieredCompactorSupplier> getCompactors() {
+        return Collections.unmodifiableCollection(compactors);
+    }
+
+    @Override
+    public void init(Map<String, String> config) {
+        // example:
+        // <table-compaction-prefix>.tiered.0.class=<majcompaction-class>
+        // <table-compaction-prefix>.tiered.0.opts.key=value
+        // <table-compaction-prefix>.tiered.1.class=<majcompaction-class>
+        // <table-compaction-prefix>.tiered.1.opts.key_a=value
+        // <table-compaction-prefix>.tiered.1.opts.key_b=value
+        //
+        // the key=value pairs will be sent to the specific tiered compaction
+        // strategy as arguments
+
+        compactors.clear();
+        createSuppliers(config);
+    }
+
+    @Override
+    public void gatherInformation(MajorCompactionRequest request) throws IOException {
+        for (TieredCompactorSupplier compactor : compactors) {
+            CompactionStrategy strategy = compactor.get(request.getTableProperties());
+            strategy.gatherInformation(request);
+        }
+    }
+
+    @Override
+    public boolean shouldCompact(MajorCompactionRequest request) throws IOException {
+        boolean shouldCompact = false;
+        for (TieredCompactorSupplier supplier : compactors) {
+            CompactionStrategy strategy = supplier.get(request.getTableProperties());
+            shouldCompact = strategy.shouldCompact(request);
+            if (shouldCompact) {
+                break;
+            }
+        }
+
+        return shouldCompact;
+    }
+
+    @Override
+    public CompactionPlan getCompactionPlan(MajorCompactionRequest request) throws IOException {
+        CompactionPlan plan = null;
+        Iterator<TieredCompactorSupplier> iter = compactors.iterator();
+        while ((null == plan || plan.inputFiles.isEmpty()) && iter.hasNext()) {
+            CompactionStrategy strategy = iter.next().get(request.getTableProperties());
+            plan = strategy.getCompactionPlan(request);
+        }
+
+        return plan;
+    }
+
+    protected void createSuppliers(Map<String, String> config) {
+        int tier = 0;
+        boolean continueLoop = true;
+        while (continueLoop) {
+            String clazzKey = TIERED_PREFIX + tier + "." + TIERED_CLASS;
+            String clazzName = config.get(clazzKey);
+            if (null != clazzName) {
+                compactors.add(new TieredConfiguredSupplier(clazzName, tier, config));
+                tier++;
+            } else {
+                continueLoop = false;
+            }
+        }
+    }
+
+    static class TieredConfiguredSupplier implements TieredCompactorSupplier {
+
+        private static final Logger LOG = LoggerFactory.getLogger(TieredConfiguredSupplier.class);
+
+        private final String clazzName;
+        private final int tier;
+        private final Map<String, String> initConfig;
+
+        private CompactionStrategy strategy;
+        private Map<String, String> options;
+
+        TieredConfiguredSupplier(String clazzName, int tier, Map<String, String> initConfig) {
+            this.strategy = null;
+            this.clazzName = clazzName;
+            this.tier = tier;
+            this.initConfig = initConfig;
+        }
+
+        public Map<String, String> options() {
+            if (null == options) {
+                options = new HashMap<>();
+                String tierCompare = Integer.toString(tier);
+                int tierIdx = TIERED_PREFIX.length();
+                int optsIdx = TIERED_PREFIX.length() + tierCompare.length() + 1;
+                for (Map.Entry<String, String> entry : initConfig.entrySet()) {
+                    String key = entry.getKey();
+                    if (key.regionMatches(tierIdx, tierCompare, 0, tierCompare.length())
+                            && key.regionMatches(optsIdx, TIERED_OPTS, 0, TIERED_OPTS.length())) {
+                        options.put(key.substring(optsIdx + TIERED_OPTS.length() + 1), entry.getValue());
+                    }
+                }
+            }
+
+            return Collections.unmodifiableMap(options);
+        }
+
+        public CompactionStrategy get(Map<String, String> tableProperties) {
+            if (null == strategy) {
+                try {
+                    String tableContext = tableProperties.get(Property.TABLE_CLASSPATH.getKey());
+                    Class<? extends CompactionStrategy> clazz;
+                    if (null != tableContext && !tableContext.equals("")) {
+                        clazz = AccumuloVFSClassLoader.getContextManager().loadClass(tableContext, clazzName,
+                                CompactionStrategy.class);
+                    } else {
+                        clazz = AccumuloVFSClassLoader.loadClass(clazzName, CompactionStrategy.class);
+                    }
+                    strategy = clazz.newInstance();
+                    strategy.init(options());
+                } catch (Exception e) {
+                    LOG.debug("Failed to load class for tiered compaction: " + e.toString());
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return strategy;
+        }
+    }
+}

--- a/server/src/main/java/timely/store/compaction/TieredCompactorSupplier.java
+++ b/server/src/main/java/timely/store/compaction/TieredCompactorSupplier.java
@@ -1,0 +1,12 @@
+package timely.store.compaction;
+
+import java.util.Map;
+
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+
+public interface TieredCompactorSupplier {
+
+    Map<String, String> options();
+
+    CompactionStrategy get(Map<String, String> tableProperties);
+}

--- a/server/src/main/java/timely/store/compaction/util/MetadataAccumulator.java
+++ b/server/src/main/java/timely/store/compaction/util/MetadataAccumulator.java
@@ -1,0 +1,130 @@
+package timely.store.compaction.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.io.Text;
+import timely.store.compaction.TabletRowAdapter;
+
+public class MetadataAccumulator {
+
+    private final List<Entry> list;
+    private Entry currentEntry;
+
+    public MetadataAccumulator() {
+        this.list = new LinkedList<>();
+    }
+
+    public Entry checkEntryState(Text tablet) {
+        // entry may be null on initial invocation or after the pushOrDiscard operation
+        // check to see if the tablet has changed, if so then
+        // push or discard the current state
+        if (currentEntry != null && !tablet.equals(currentEntry.getTablet())) {
+            pushOrDiscardEntry();
+        }
+        if (currentEntry == null) {
+            currentEntry = new Entry(tablet);
+        }
+
+        return currentEntry;
+    }
+
+    public Collection<Entry> getEntries() {
+        return Collections.unmodifiableCollection(list);
+    }
+
+    public void ensureState() {
+        pushOrDiscardEntry();
+    }
+
+    private void pushOrDiscardEntry() {
+        if (currentEntry != null && currentEntry.hasFiles()) {
+            list.add(currentEntry);
+        }
+        currentEntry = null;
+    }
+
+    public static class Entry {
+
+        private final Text tablet;
+        private final String tabletPrefix;
+        private final boolean hasTabletOffset;
+        private final long tabletOffset;
+        private Text tabletPrev;
+        private long milliseconds;
+        private long totalBytes;
+        private int totalFiles;
+
+        public Entry(Text tablet) {
+            this.tablet = tablet;
+            Optional<String> prefixOptional = TabletRowAdapter.decodeRowPrefix(tablet);
+            OptionalLong offsetOptional = TabletRowAdapter.decodeRowOffset(tablet);
+            tabletPrefix = prefixOptional.orElseGet(tablet::toString);
+            if (offsetOptional.isPresent()) {
+                hasTabletOffset = true;
+                tabletOffset = offsetOptional.getAsLong();
+            } else {
+                hasTabletOffset = false;
+                tabletOffset = -1;
+            }
+        }
+
+        public String getTabletPrefix() {
+            return tabletPrefix;
+        }
+
+        public Text getTablet() {
+            return tablet;
+        }
+
+        public Text getTabletPrev() {
+            return tabletPrev;
+        }
+
+        public long getMilliseconds() {
+            return milliseconds;
+        }
+
+        public long getTotalFileBytes() {
+            return totalBytes;
+        }
+
+        public int getTotalFiles() {
+            return totalFiles;
+        }
+
+        public OptionalLong getTabletOffset() {
+            return hasTabletOffset ? OptionalLong.of(tabletOffset) : OptionalLong.empty();
+        }
+
+        public boolean hasFiles() {
+            return totalFiles > 0;
+        }
+
+        public void addFile(long size) {
+            totalFiles++;
+            totalBytes += size;
+        }
+
+        public void setTablePrev(Text prev) {
+            tabletPrev = prev;
+        }
+
+        public void setMilliseconds(long val) {
+            milliseconds = val;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("metadata.entry {tablet: %s, millis: %d, offset-ms: %d, age-days: %d, files %d}",
+                    tablet, milliseconds, tabletOffset,
+                    (hasTabletOffset ? TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - tabletOffset) : -1),
+                    totalFiles);
+        }
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletMetadataConsole.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletMetadataConsole.java
@@ -1,0 +1,41 @@
+package timely.store.compaction.util;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.springframework.boot.Banner;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import timely.configuration.Accumulo;
+import timely.configuration.Configuration;
+import timely.configuration.SpringBootstrap;
+
+public class TabletMetadataConsole {
+
+    public static void main(String[] args) throws Exception {
+        try (ConfigurableApplicationContext ctx = new SpringApplicationBuilder(SpringBootstrap.class)
+                .bannerMode(Banner.Mode.OFF).web(WebApplicationType.NONE).run(args)) {
+            Configuration conf = ctx.getBean(Configuration.class);
+            BaseConfiguration apacheConf = new BaseConfiguration();
+            Accumulo accumuloConf = conf.getAccumulo();
+            apacheConf.setProperty("instance.name", accumuloConf.getInstanceName());
+            apacheConf.setProperty("instance.zookeeper.host", accumuloConf.getZookeepers());
+            ClientConfiguration aconf = new ClientConfiguration(Collections.singletonList(apacheConf));
+            Instance instance = new ZooKeeperInstance(aconf);
+            Connector con = instance.getConnector(accumuloConf.getUsername(),
+                    new PasswordToken(accumuloConf.getPassword()));
+
+            TabletMetadataQuery query = new TabletMetadataQuery(con, conf.getMetricsTable());
+            TabletMetadataView view = query.run();
+
+            System.out.println(view.toText(TimeUnit.DAYS));
+        }
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletMetadataFormatter.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletMetadataFormatter.java
@@ -1,0 +1,31 @@
+package timely.store.compaction.util;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.util.format.AggregatingFormatter;
+
+public class TabletMetadataFormatter extends AggregatingFormatter {
+
+    private final TabletMetadataView view;
+
+    public TabletMetadataFormatter() {
+        this(new TabletMetadataView());
+    }
+
+    public TabletMetadataFormatter(TabletMetadataView view) {
+        this.view = view;
+    }
+
+    @Override
+    public void aggregateStats(Map.Entry<Key, Value> entry) {
+        view.addEntry(entry);
+    }
+
+    @Override
+    protected String getStats() {
+        return view.toText(TimeUnit.DAYS);
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletMetadataQuery.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletMetadataQuery.java
@@ -1,0 +1,44 @@
+package timely.store.compaction.util;
+
+import java.util.Map;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.MetadataTable;
+
+public class TabletMetadataQuery {
+
+    private final Connector connector;
+    private final String tableName;
+
+    public TabletMetadataQuery(Connector connector, String tableName) {
+        this.connector = connector;
+        this.tableName = tableName;
+    }
+
+    public TabletMetadataView run() throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+        TabletMetadataView view = new TabletMetadataView();
+        Map<String, String> tableMap = connector.tableOperations().tableIdMap();
+        String tableId = tableMap.get(tableName);
+        if (null == tableId) {
+            throw new IllegalStateException("Unable to find " + MetadataTable.NAME);
+        }
+
+        try (Scanner s = connector.createScanner(MetadataTable.NAME,
+                connector.securityOperations().getUserAuthorizations(connector.whoami()))) {
+            // s.setRange(new Range(tableId, true, tableId, true));
+            s.setRange(Range.prefix(tableId));
+            for (Map.Entry<Key, Value> e : s) {
+                view.addEntry(e);
+            }
+        }
+
+        return view;
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletMetadataView.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletMetadataView.java
@@ -1,0 +1,144 @@
+package timely.store.compaction.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
+import org.apache.hadoop.io.Text;
+
+public class TabletMetadataView {
+
+    private final MetadataAccumulator accumulator;
+
+    private static final int DEFAULT_TOP_COUNT = 25;
+
+    public TabletMetadataView() {
+        accumulator = new MetadataAccumulator();
+    }
+
+    public void addEntry(Collection<Map.Entry<Key, Value>> entries) {
+        for (Map.Entry<Key, Value> entry : entries) {
+            addEntry(entry);
+        }
+    }
+
+    public void addEntry(Map.Entry<Key, Value> entry) {
+        KeyExtent ke = new KeyExtent(entry.getKey().getRow(), (Text) null);
+        if (ke.getEndRow() == null) {
+            return;
+        }
+
+        Text cf = entry.getKey().getColumnFamily();
+        Text cq = entry.getKey().getColumnQualifier();
+        MetadataAccumulator.Entry candidate = accumulator.checkEntryState(ke.getEndRow());
+
+        if (cf.equals(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME)) {
+            String val = entry.getValue().toString();
+            String[] valSplit = val.split(",");
+            if (valSplit.length == 2) {
+                long size = Long.parseLong(valSplit[0]);
+                candidate.addFile(size);
+            }
+        } else if (cf.equals(MetadataSchema.TabletsSection.ServerColumnFamily.NAME)) {
+            if (cq.equals(MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN.getColumnQualifier())) {
+                String timeVal = entry.getValue().toString();
+                if (timeVal.startsWith("M")) {
+                    long ms = Long.parseLong(timeVal.substring(1));
+                    candidate.setMilliseconds(ms);
+                }
+            }
+        } else if (cf.equals(MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily())
+                && cq.equals(MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier())) {
+            ke = new KeyExtent(entry.getKey().getRow(), entry.getValue());
+            candidate.setTablePrev(ke.getPrevEndRow());
+        }
+    }
+
+    public Collection<MetadataAccumulator.Entry> getEntries() {
+        accumulator.ensureState();
+        return accumulator.getEntries();
+    }
+
+    public TabletSummary.Builder computeSummary() {
+        return TabletSummary.newBuilder(getEntries());
+    }
+
+    public String toText() {
+        return toText(TimeUnit.MILLISECONDS);
+    }
+
+    public String toText(TimeUnit unit) {
+        if (getEntries().isEmpty()) {
+            return "No results";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        TabletSummary summary = computeSummary().build();
+        Map<TabletStatisticType, StatisticalSummary> tabletAggregate = summary.aggregateSummary();
+        StatisticalSummary tabletSizes = tabletAggregate.get(TabletStatisticType.SIZE);
+        StatisticalSummary tabletTime = tabletAggregate.get(TabletStatisticType.TIME);
+        long tabletMax = unit.convert((long) tabletTime.getMax(), TimeUnit.MILLISECONDS);
+        long tabletMean = unit.convert((long) tabletTime.getMean(), TimeUnit.MILLISECONDS);
+        Collection<TabletStatistic> topOldestMetrics = summary.findTabletPrefixesByOldest(DEFAULT_TOP_COUNT);
+        Collection<TabletStatistic> topSizeMetrics = summary.findTabletPrefixesByLargest(DEFAULT_TOP_COUNT);
+
+        sb.append(String.format("Tablets { prefix: %d, total: %d } %s", summary.totalTabletPrefixes(),
+                summary.totalTablets(), System.lineSeparator()));
+        sb.append(System.lineSeparator());
+        sb.append(String.format("Size: { sum: %s, avg: %s } %s",
+                FileUtils.byteCountToDisplaySize((long) tabletSizes.getSum()),
+                FileUtils.byteCountToDisplaySize((long) tabletSizes.getMean()), System.lineSeparator()));
+
+        sb.append(String.format("Age: { max: %d, avg: %d } %s", tabletMax, tabletMean, System.lineSeparator()));
+
+        sb.append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+
+        sb.append(String.format("Top %d Tablets (by-age) %s", DEFAULT_TOP_COUNT, System.lineSeparator()));
+        sb.append("---");
+        sb.append(System.lineSeparator());
+
+        for (TabletStatistic entry : topOldestMetrics) {
+            sb.append(String.format("%s = { tablets: %d, max-age: %d } %s", entry.getKeyName(), entry.getKeyCount(),
+                    unit.convert(entry.maxAge(), TimeUnit.MILLISECONDS), System.lineSeparator()));
+        }
+
+        sb.append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+
+        sb.append(String.format("Top %d Tablets (by-size) %s", DEFAULT_TOP_COUNT, System.lineSeparator()));
+        sb.append("---");
+        sb.append(System.lineSeparator());
+
+        for (TabletStatistic entry : topSizeMetrics) {
+            long totalSize = (long) entry.getSummary(TabletStatisticType.SIZE).getSum();
+            sb.append(String.format("%s = { tablets: %d, size: %s } %s", entry.getKeyName(), entry.getKeyCount(),
+                    FileUtils.byteCountToDisplaySize(totalSize), System.lineSeparator()));
+        }
+
+        sb.append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+
+        sb.append(String.format("Tablets (by-name) %s", System.lineSeparator()));
+        sb.append("---");
+        sb.append(System.lineSeparator());
+
+        for (TabletStatistic entry : summary.getSummary()) {
+            long totalSize = (long) entry.getSummary(TabletStatisticType.SIZE).getSum();
+            sb.append(String.format("%s = { tablets: %d, size: %s, max-age: %d } %s", entry.getKeyName(),
+                    entry.getKeyCount(), FileUtils.byteCountToDisplaySize(totalSize),
+                    unit.convert(entry.maxAge(), TimeUnit.MILLISECONDS), System.lineSeparator()));
+        }
+
+        sb.append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+
+        return sb.toString();
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletStatistic.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletStatistic.java
@@ -1,0 +1,53 @@
+package timely.store.compaction.util;
+
+import java.util.Map;
+
+import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+
+public class TabletStatistic {
+
+    private final String keyName;
+    private final int keyCount;
+    private final Map<TabletStatisticType, SummaryStatistics> stats;
+    private final SummaryStatistics timeStat;
+    private final SummaryStatistics sizeStat;
+
+    TabletStatistic(String keyName, int keyCount, Map<TabletStatisticType, SummaryStatistics> stats) {
+        this.keyName = keyName;
+        this.keyCount = keyCount;
+        this.stats = stats;
+
+        timeStat = stats.getOrDefault(TabletStatisticType.TIME, new SummaryStatistics());
+        sizeStat = stats.getOrDefault(TabletStatisticType.SIZE, new SummaryStatistics());
+    }
+
+    public String getKeyName() {
+        return keyName;
+    }
+
+    public int getKeyCount() {
+        return keyCount;
+    }
+
+    public StatisticalSummary getSummary(TabletStatisticType statType) {
+        return this.stats.getOrDefault(statType, new SummaryStatistics());
+    }
+
+    public Map<TabletStatisticType, SummaryStatistics> getSummaryMap() {
+        return stats;
+    }
+
+    public long maxAge() {
+        return (long) timeStat.getMax();
+    }
+
+    public long totalSize() {
+        return (long) sizeStat.getSum();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("key: %s, count: %d, age: %d, size %d", keyName, keyCount, maxAge(), totalSize());
+    }
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletStatisticType.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletStatisticType.java
@@ -1,0 +1,5 @@
+package timely.store.compaction.util;
+
+public enum TabletStatisticType {
+    SIZE, TIME
+}

--- a/server/src/main/java/timely/store/compaction/util/TabletSummary.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletSummary.java
@@ -1,0 +1,155 @@
+package timely.store.compaction.util;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.math3.stat.descriptive.AggregateSummaryStatistics;
+import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import timely.store.compaction.TabletRowAdapter;
+
+public class TabletSummary {
+
+    private final Collection<TabletStatistic> tabletStats;
+
+    private TabletSummary(Collection<TabletStatistic> tabletStats) {
+        this.tabletStats = tabletStats;
+    }
+
+    public static Builder newBuilder(Collection<MetadataAccumulator.Entry> entries) {
+        return new Builder(entries);
+    }
+
+    public Map<TabletStatisticType, StatisticalSummary> aggregateSummary() {
+        // @formatter:off
+        return tabletStats.stream()
+                .flatMap(m -> m.getSummaryMap().entrySet().stream())
+                .collect(Collectors.groupingBy(Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())))
+                .entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, v -> AggregateSummaryStatistics.aggregate(v.getValue())));
+    }
+
+    public long totalTabletPrefixes() {
+        return tabletStats.size();
+    }
+
+    public long totalTablets() {
+        // @formatter:off
+        return tabletStats.stream()
+                .mapToLong(TabletStatistic::getKeyCount)
+                .sum();
+    }
+
+    public Collection<TabletStatistic> findTabletPrefixesByOldest(int count) {
+        // @formatter:off
+        return tabletStats.stream()
+                .sorted(Comparator.comparingLong(TabletStatistic::maxAge)
+                        .reversed()
+                        .thenComparing(TabletStatistic::getKeyName))
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+
+    public Collection<TabletStatistic> findTabletPrefixesByLargest(int count) {
+        // @formatter:off
+        return tabletStats.stream()
+                .sorted(Comparator.comparingLong(TabletStatistic::totalSize)
+                        .reversed()
+                        .thenComparing(TabletStatistic::getKeyName))
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+
+    public Collection<TabletStatistic> getSummary() {
+        return tabletStats;
+    }
+
+    public static class Builder {
+        private final Collection<MetadataAccumulator.Entry> entries;
+        private long explictTimeMillis;
+        private boolean useExplicitTime;
+        private boolean disableTabletRowCheckFilter;
+
+        public Builder(Collection<MetadataAccumulator.Entry> entries) {
+            this.entries = entries;
+        }
+
+        public Builder currentTime(long millis) {
+            explictTimeMillis = millis;
+            useExplicitTime = true;
+            return this;
+        }
+
+        public Builder disableTabletRowCheckFilter() {
+            disableTabletRowCheckFilter = true;
+            return this;
+        }
+
+        public TabletSummary build() {
+            Stream<MetadataAccumulator.Entry> stream = entries.stream();
+            if (!disableTabletRowCheckFilter) {
+                stream = stream.filter(Builder::tabletEndAnPrevAreSame);
+            }
+
+            // @formatter:off
+            Collection<TabletStatistic> tabletStats = stream
+                    .collect(Collectors.groupingBy(MetadataAccumulator.Entry::getTabletPrefix)).entrySet()
+                    .stream()
+                    .map(m -> computeStatistic(m.getValue(), m.getKey()))
+                    .sorted(Comparator.comparing(TabletStatistic::getKeyName))
+                    .collect(Collectors.toList());
+
+            // @formatter:on
+            return new TabletSummary(tabletStats);
+        }
+
+        private TabletStatistic computeStatistic(Collection<MetadataAccumulator.Entry> entries, String keyName) {
+            Map<TabletStatisticType, SummaryStatistics> stats = new HashMap<>(TabletStatisticType.values().length);
+            int maxSize = entries.size();
+            long timeMillis = useExplicitTime ? explictTimeMillis : System.currentTimeMillis();
+            for (TabletStatisticType statType : TabletStatisticType.values()) {
+                SummaryStatistics summaryStat = new SummaryStatistics();
+                Iterator<MetadataAccumulator.Entry> iterator = entries.iterator();
+                int idx = 0;
+                while (iterator.hasNext() && idx < maxSize) {
+                    MetadataAccumulator.Entry e = iterator.next();
+                    double d;
+                    switch (statType) {
+                        case SIZE:
+                            d = e.getTotalFileBytes();
+                            break;
+                        case TIME:
+                            // check the row key offset first; this was done to support
+                            // tests so that they age could function from the row-key
+                            // the tablets that do not have a key will use the modification time
+                            d = timeMillis - e.getTabletOffset().orElse(e.getMilliseconds());
+                            break;
+                        default:
+                            throw new IllegalStateException("Undefined switch case: " + statType.name());
+                    }
+                    summaryStat.addValue(d);
+                    idx++;
+                }
+                stats.put(statType, summaryStat);
+            }
+
+            return new TabletStatistic(keyName, entries.size(), stats);
+        }
+
+        private static boolean tabletEndAnPrevAreSame(MetadataAccumulator.Entry entry) {
+            if ((null == entry.getTablet()) || (null == entry.getTabletPrev())) {
+                return false;
+            }
+            Optional<String> o1 = TabletRowAdapter.decodeRowPrefix(entry.getTablet());
+            Optional<String> o2 = TabletRowAdapter.decodeRowPrefix(entry.getTabletPrev());
+            return o1.equals(o2);
+        }
+    }
+}

--- a/server/src/test/java/timely/store/compaction/MetricCompactionStrategyTest.java
+++ b/server/src/test/java/timely/store/compaction/MetricCompactionStrategyTest.java
@@ -1,0 +1,290 @@
+package timely.store.compaction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.tserver.compaction.CompactionPlan;
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
+import org.junit.Test;
+import timely.test.CompactionRequestBuilder;
+
+public class MetricCompactionStrategyTest {
+
+    private static final long TIME_MILLIS = new GregorianCalendar(2019, Calendar.JANUARY, 1).getTimeInMillis();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void initThrowsWhenNoDefaultAgeOff() {
+        Map<String, String> config = new HashMap<>();
+        MetricCompactionStrategy strategy = new MetricCompactionStrategy();
+        strategy.init(config);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder()
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        MajorCompactionRequest request = builder.build();
+        strategy.shouldCompact(request);
+    }
+
+    @Test
+    public void minAgeOffOverridesMajcDefaultWillUseMaximum() throws IOException {
+        Map<String, String> config = new HashMap<>();
+        config.put(MetricCompactionStrategy.MIN_AGEOFF_KEY, Long.toString(TimeUnit.DAYS.toMillis(10)));
+        CompactionStrategy strategy = newStrategy(config);
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(13)
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void minAgeOffOverridesMajcDefaultNotCompact() throws IOException {
+        Map<String, String> config = new HashMap<>();
+        config.put(MetricCompactionStrategy.MIN_AGEOFF_KEY, Long.toString(TimeUnit.DAYS.toMillis(13)));
+        CompactionStrategy strategy = newStrategy(config);
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void compactFilesIfKeyIsPastAgeOff() throws IOException {
+        String f1 = "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf";
+        String f2 = "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf";
+        String f3 = "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao6.rf";
+        CompactionStrategy strategy = newStrategy();
+
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys", TimeUnit.DAYS.toMillis(12))
+                .file(f1, 12, 1)
+                .file(f2, 11, 1)
+                .file(f3, 16, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertTrue(shouldCompact);
+        assertNotNull(plan);
+
+        assertEquals(3, plan.inputFiles.size());
+        assertEquals(f1, plan.inputFiles.get(0).path().toString());
+        assertEquals(f2, plan.inputFiles.get(1).path().toString());
+        assertEquals(f3, plan.inputFiles.get(2).path().toString());
+    }
+
+    @Test
+    public void noCompactionIfPrevKeyIsDifferent() throws IOException {
+        CompactionStrategy strategy = newStrategy();
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys.mem", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void noCompactionIfPrevKeyIsNull() throws IOException {
+        CompactionStrategy strategy = newStrategy();
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys", TimeUnit.DAYS.toMillis(11))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void noCompactionWhenExceedsButDoesNotHaveFiles() throws IOException {
+        CompactionStrategy strategy = newStrategy();
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys", TimeUnit.DAYS.toMillis(12));
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void noCompactionIfKeyIsNotOffset() throws IOException {
+        CompactionStrategy strategy = newStrategy();
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetricNonOffset("sys.mem", null)
+                .prevEndKeyMetricNonOffset("sys.cpu", null)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void noCompactionIfKeyIsWrongOffset() throws IOException {
+        CompactionStrategy strategy = newStrategy();
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetricNonOffset("sys.cpu", "test2")
+                .prevEndKeyMetricNonOffset("sys.cpu", "test1")
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void compactWithLogOnlyDoesNotCompact() throws IOException {
+        Map<String, String> defaults = new HashMap<>();
+        defaults.put(MetricCompactionStrategy.LOG_ONLY_KEY, "true");
+        CompactionStrategy strategy = newStrategy(defaults);
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    @Test
+    public void compactWithFilterPrefixWillCompact() throws IOException {
+        Map<String, String> defaults = new HashMap<>();
+        defaults.put(MetricCompactionStrategy.FILTER_PREFIX_KEY, "sys.cp");
+        CompactionStrategy strategy = newStrategy(defaults);
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertTrue(shouldCompact);
+        assertNotNull(plan);
+
+        assertEquals(2, plan.inputFiles.size());
+    }
+
+    @Test
+    public void compactWithoutFilterPrefixWillNotCompact() throws IOException {
+        Map<String, String> defaults = new HashMap<>();
+        defaults.put(MetricCompactionStrategy.FILTER_PREFIX_KEY, "sys.mem");
+        CompactionStrategy strategy = newStrategy(defaults);
+        // @formatter:off
+        CompactionRequestBuilder builder = newRequestBuilder(10)
+                .endKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(11))
+                .prevEndKeyMetric("sys.cpu", TimeUnit.DAYS.toMillis(12))
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", 1, 1)
+                .file("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao7.rf", 1, 1);
+
+        // @formatter:on
+        MajorCompactionRequest request = builder.build();
+        boolean shouldCompact = strategy.shouldCompact(request);
+        CompactionPlan plan = strategy.getCompactionPlan(request);
+
+        assertFalse(shouldCompact);
+        assertNull(plan);
+    }
+
+    private static CompactionRequestBuilder newRequestBuilder(int defaultAgeOffDays) {
+        return new CompactionRequestBuilder(TIME_MILLIS).tableProperties(
+                Property.TABLE_ITERATOR_MAJC_PREFIX.getKey() + "ageoffmetrics.opt.ageoff.default",
+                Long.toString(TimeUnit.DAYS.toMillis(defaultAgeOffDays)));
+    }
+
+    private static MetricCompactionStrategy newStrategy() {
+        return newStrategy(new TreeMap<>());
+    }
+
+    private static MetricCompactionStrategy newStrategy(Map<String, String> config) {
+        if (!config.containsKey(MetricCompactionStrategy.LOG_ONLY_KEY)) {
+            config.put(MetricCompactionStrategy.LOG_ONLY_KEY, "false");
+        }
+        MetricCompactionStrategy strategy = new MetricCompactionStrategy();
+        strategy.setExplicitTime(TIME_MILLIS);
+        strategy.init(config);
+        return strategy;
+    }
+}

--- a/server/src/test/java/timely/store/compaction/TabletRowAdapterTest.java
+++ b/server/src/test/java/timely/store/compaction/TabletRowAdapterTest.java
@@ -1,0 +1,79 @@
+package timely.store.compaction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.OptionalLong;
+
+import org.apache.accumulo.core.client.lexicoder.Lexicoder;
+import org.apache.accumulo.core.client.lexicoder.LongLexicoder;
+import org.apache.accumulo.core.client.lexicoder.PairLexicoder;
+import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.util.ComparablePair;
+import org.apache.hadoop.io.Text;
+import org.easymock.EasyMock;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class TabletRowAdapterTest {
+
+    private static final Lexicoder<String> prefixCoder = new StringLexicoder();
+    private static final Lexicoder<Long> offsetCoder = new LongLexicoder();
+    private static final PairLexicoder<String, Long> pairCoder = new PairLexicoder<>(prefixCoder, offsetCoder);
+
+    @Test
+    public void decodePrefix() {
+        ComparablePair<String, Long> p = new ComparablePair<>("test", 1L);
+        byte[] bytes = pairCoder.encode(p);
+        OptionalLong decoded = TabletRowAdapter.decodeRowOffset(new Text(bytes));
+        assertTrue(decoded.isPresent());
+    }
+
+    @Test
+    public void decodeOffsetOnly() {
+        ComparablePair<String, Long> p = new ComparablePair<>("test", 1L);
+        byte[] bytes = pairCoder.encode(p);
+        OptionalLong decoded = TabletRowAdapter.decodeRowOffset(new Text(bytes));
+        assertTrue(decoded.isPresent());
+        assertEquals(1L, decoded.getAsLong());
+    }
+
+    @Test
+    public void decodeOffsetWithTruncatedOffset() {
+        // offset is truncated on tablet extents
+        long truncateOffset = 1554962382848L;
+        ComparablePair<String, Long> p = new ComparablePair<>("sys.disk.disk_octets", truncateOffset);
+        byte[] bytes = pairCoder.encode(p);
+        bytes = Arrays.copyOf(bytes, bytes.length - 4);
+        OptionalLong decoded = TabletRowAdapter.decodeRowOffset(new Text(bytes));
+        assertTrue(decoded.isPresent());
+        assertEquals(truncateOffset, decoded.getAsLong());
+    }
+
+    @Test
+    public void decodeOffsetWithBadDataWillSet() {
+        ComparablePair<String, String> p = new ComparablePair<>("test", "<");
+        byte[] bytes = new PairLexicoder<>(prefixCoder, prefixCoder).encode(p);
+        OptionalLong decoded = TabletRowAdapter.decodeRowOffset(new Text(bytes));
+        assertFalse(decoded.isPresent());
+    }
+
+    @Test
+    public void debugOutputTest() {
+        long offset = 1554962382848L;
+        ComparablePair<String, Long> p = new ComparablePair<>("sys.disk.disk_octets", offset);
+        byte[] bytes = pairCoder.encode(p);
+        TabletId tid = EasyMock.createMock(TabletId.class);
+        EasyMock.expect(tid.getEndRow()).andReturn(new Text(bytes));
+        EasyMock.replay(tid);
+
+        String debug = TabletRowAdapter.toDebugOutput(tid);
+        assertThat(debug, CoreMatchers.containsString("prefix: sys.disk.disk_octets"));
+        assertThat(debug, CoreMatchers.containsString("date: 2019-04-11T05:59:42.848"));
+        assertThat(debug, CoreMatchers.containsString("millis: 1554962382848"));
+    }
+}

--- a/server/src/test/java/timely/store/compaction/TieredCompactionStrategyTest.java
+++ b/server/src/test/java/timely/store/compaction/TieredCompactionStrategyTest.java
@@ -1,0 +1,236 @@
+package timely.store.compaction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import org.apache.accumulo.server.fs.FileRef;
+import org.apache.accumulo.tserver.compaction.CompactionPlan;
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+import org.apache.accumulo.tserver.compaction.DefaultCompactionStrategy;
+import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import timely.test.CompactionRequestBuilder;
+
+public class TieredCompactionStrategyTest {
+
+    @Test
+    public void initConfiguresWithMultipleTiers() {
+        Map<String, String> config = new HashMap<>();
+        config.put("tier.0.class", DefaultCompactionStrategy.class.getName());
+        config.put("tier.0.opts.arg1", "foo");
+        config.put("tier.0.opts.arg2", "sys");
+        config.put("tier.1.class", DefaultCompactionStrategy.class.getName());
+        config.put("tier.1.opts.arg1", "bar");
+        config.put("tier.2.class", DefaultCompactionStrategy.class.getName());
+
+        TieredCompactionStrategy strategy = new TieredCompactionStrategy();
+        strategy.init(config);
+        List<TieredCompactorSupplier> suppliers = Lists.newArrayList(strategy.getCompactors());
+        assertEquals(3, suppliers.size());
+        assertEquals(2, suppliers.get(0).options().size());
+        assertEquals(1, suppliers.get(1).options().size());
+        assertEquals(0, suppliers.get(2).options().size());
+        assertEquals("foo", suppliers.get(0).options().get("arg1"));
+        assertEquals("sys", suppliers.get(0).options().get("arg2"));
+        assertEquals("bar", suppliers.get(1).options().get("arg1"));
+    }
+
+    @Test
+    public void initConfiguresWithSingleTierNoArguments() {
+        Map<String, String> config = new HashMap<>();
+        config.put("tier.0.class", DefaultCompactionStrategy.class.getName());
+
+        TieredCompactionStrategy strategy = new TieredCompactionStrategy();
+        strategy.init(config);
+        List<TieredCompactorSupplier> suppliers = Lists.newArrayList(strategy.getCompactors());
+        assertEquals(1, suppliers.size());
+        assertEquals(0, suppliers.get(0).options().size());
+    }
+
+    @Test
+    public void gatherInformationAcrossTiers() throws IOException {
+        CompactionStrategy c1 = EasyMock.createMock(CompactionStrategy.class);
+        CompactionStrategy c2 = EasyMock.createMock(CompactionStrategy.class);
+
+        c1.gatherInformation(EasyMock.anyObject());
+        EasyMock.expectLastCall();
+
+        c2.gatherInformation(EasyMock.anyObject());
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(c1, c2);
+
+        TieredCompactionStrategy strategy = newStrategy(c1, c2);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        strategy.gatherInformation(request);
+
+        EasyMock.verify(c1, c2);
+    }
+
+    @Test
+    public void shouldCompactStopsAtTier() throws IOException {
+        CompactionStrategy c1 = EasyMock.createMock("c1", CompactionStrategy.class);
+        CompactionStrategy c2 = EasyMock.createMock("c2", CompactionStrategy.class);
+        CompactionStrategy c3 = EasyMock.createMock("c3", CompactionStrategy.class);
+
+        EasyMock.expect(c1.shouldCompact(EasyMock.anyObject())).andReturn(false);
+        EasyMock.expect(c2.shouldCompact(EasyMock.anyObject())).andReturn(true);
+
+        EasyMock.replay(c1, c2, c3);
+
+        TieredCompactionStrategy strategy = newStrategy(c1, c2, c3);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        boolean result = strategy.shouldCompact(request);
+
+        assertTrue(result);
+        EasyMock.verify(c1, c2, c3);
+    }
+
+    @Test
+    public void shouldCompactWithSingleTier() throws Exception {
+        CompactionStrategy c1 = EasyMock.createMock("c1", CompactionStrategy.class);
+
+        EasyMock.expect(c1.shouldCompact(EasyMock.anyObject())).andReturn(false);
+        EasyMock.replay(c1);
+
+        TieredCompactionStrategy strategy = newStrategy(c1);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        boolean result = strategy.shouldCompact(request);
+
+        assertFalse(result);
+        EasyMock.verify(c1);
+    }
+
+    @Test
+    public void getCompactionPlanSkipsAndStopsAtTier() throws IOException {
+        CompactionPlan p1 = new CompactionPlan();
+        p1.inputFiles.add(new FileRef("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf"));
+
+        CompactionStrategy c1 = EasyMock.createMock("c1", CompactionStrategy.class);
+        CompactionStrategy c2 = EasyMock.createMock("c2", CompactionStrategy.class);
+        CompactionStrategy c3 = EasyMock.createMock("c3", CompactionStrategy.class);
+
+        EasyMock.expect(c1.getCompactionPlan(EasyMock.anyObject())).andReturn(null);
+        EasyMock.expect(c2.getCompactionPlan(EasyMock.anyObject())).andReturn(p1);
+
+        EasyMock.replay(c1, c2, c3);
+
+        TieredCompactionStrategy strategy = newStrategy(c1, c2, c3);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        CompactionPlan actualPlan = strategy.getCompactionPlan(request);
+
+        assertNotNull(actualPlan);
+        assertSame(p1, actualPlan);
+        EasyMock.verify(c1, c2, c3);
+    }
+
+    @Test
+    public void getCompactionPlanSkipsWhenEmptyInputAndStopsAtTier() throws IOException {
+        CompactionPlan p1 = new CompactionPlan();
+        p1.inputFiles.add(new FileRef("hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf"));
+
+        CompactionStrategy c1 = EasyMock.createMock("c1", CompactionStrategy.class);
+        CompactionStrategy c2 = EasyMock.createMock("c2", CompactionStrategy.class);
+        CompactionStrategy c3 = EasyMock.createMock("c3", CompactionStrategy.class);
+
+        EasyMock.expect(c1.getCompactionPlan(EasyMock.anyObject())).andReturn(new CompactionPlan());
+        EasyMock.expect(c2.getCompactionPlan(EasyMock.anyObject())).andReturn(p1);
+
+        EasyMock.replay(c1, c2, c3);
+
+        TieredCompactionStrategy strategy = newStrategy(c1, c2, c3);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        CompactionPlan actualPlan = strategy.getCompactionPlan(request);
+
+        assertNotNull(actualPlan);
+        assertSame(p1, actualPlan);
+        EasyMock.verify(c1, c2, c3);
+    }
+
+    @Test
+    public void getCompactionPlanWillReturnNullIfNonCompact() throws IOException {
+        CompactionStrategy c1 = EasyMock.createMock("c1", CompactionStrategy.class);
+        CompactionStrategy c2 = EasyMock.createMock("c2", CompactionStrategy.class);
+        CompactionStrategy c3 = EasyMock.createMock("c3", CompactionStrategy.class);
+
+        EasyMock.expect(c1.getCompactionPlan(EasyMock.anyObject())).andReturn(null);
+        EasyMock.expect(c2.getCompactionPlan(EasyMock.anyObject())).andReturn(null);
+        EasyMock.expect(c3.getCompactionPlan(EasyMock.anyObject())).andReturn(null);
+
+        EasyMock.replay(c1, c2, c3);
+
+        TieredCompactionStrategy strategy = newStrategy(c1, c2, c3);
+        CompactionRequestBuilder builder = new CompactionRequestBuilder();
+        MajorCompactionRequest request = builder.build();
+
+        CompactionPlan actualPlan = strategy.getCompactionPlan(request);
+
+        assertNull(actualPlan);
+        EasyMock.verify(c1, c2, c3);
+    }
+
+    private static TieredCompactionStrategy newStrategy(CompactionStrategy... strategies) {
+        Collection<TieredCompactorSupplier> mockSuppliers = new ArrayList<>();
+        for (CompactionStrategy s : strategies) {
+            mockSuppliers.add(new MockSupplier(s));
+        }
+        // @formatter:off
+        TieredCompactionStrategy strategy = EasyMock.partialMockBuilder(TieredCompactionStrategy.class)
+                .withConstructor()
+                .addMockedMethod("createSuppliers")
+                .createMock();
+
+        // @formatter:on
+        strategy.createSuppliers(EasyMock.anyObject());
+        EasyMock.expectLastCall().andAnswer(() -> strategy.compactors.addAll(mockSuppliers));
+
+        EasyMock.replay(strategy);
+
+        strategy.init(Collections.emptyMap());
+
+        return strategy;
+    }
+
+    static class MockSupplier implements TieredCompactorSupplier {
+
+        private final CompactionStrategy strategy;
+
+        MockSupplier(CompactionStrategy strategy) {
+            this.strategy = strategy;
+        }
+
+        @Override
+        public Map<String, String> options() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public CompactionStrategy get(Map<String, String> tableProperites) {
+            return strategy;
+        }
+    }
+}

--- a/server/src/test/java/timely/store/compaction/util/TabletMetadataFormatterTest.java
+++ b/server/src/test/java/timely/store/compaction/util/TabletMetadataFormatterTest.java
@@ -1,0 +1,42 @@
+package timely.store.compaction.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.util.format.FormatterConfig;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+import timely.adapter.accumulo.MetricAdapter;
+import timely.test.TestTabletMetadata;
+
+public class TabletMetadataFormatterTest {
+
+    @Test
+    public void simpleTextOutput() {
+        Long a1 = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+        Long a2 = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(29);
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", a1));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", a2));
+
+        // @formatter:off
+        Collection<Map.Entry<Key, Value>> metadata = new TestTabletMetadata("2")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .prev(r1, null)
+                .time(r1, a1)
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao0.rf", "451,2")
+                .time(r2, a2)
+                .prev(r2, r1)
+                .entries();
+
+        // @formatter:on
+        TabletMetadataFormatter f = new TabletMetadataFormatter();
+        f.initialize(metadata, new FormatterConfig());
+        System.out.println(f.next());
+    }
+}

--- a/server/src/test/java/timely/store/compaction/util/TabletMetadataViewTest.java
+++ b/server/src/test/java/timely/store/compaction/util/TabletMetadataViewTest.java
@@ -1,0 +1,106 @@
+package timely.store.compaction.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Lists;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+import timely.adapter.accumulo.MetricAdapter;
+import timely.test.TestTabletMetadata;
+
+public class TabletMetadataViewTest {
+
+    @Test
+    public void tabletAccumulate() {
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", 1L));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.mem", 1L));
+        Text r3 = new Text(MetricAdapter.encodeRowKey("sys.disk", 1L));
+
+        // @formatter:off
+        Collection<Map.Entry<Key, Value>> metadata = new TestTabletMetadata("2")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .prev(r1, null)
+                .time(r1, 1)
+                .time(r2, 2)
+                .prev(r2, r3)
+                .file(r3, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r3, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .file(r3, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao0.rf", "451,2")
+                .time(r3, 3)
+                .prev(r3, r1)
+                .entries();
+
+        // assert that r1/r2 are in the output correctly
+        // r2 does not have any files, it should not appear in the output
+        // @formatter:on
+        TabletMetadataView view = new TabletMetadataView();
+        view.addEntry(metadata);
+        List<MetadataAccumulator.Entry> accumulated = Lists.newArrayList(view.getEntries());
+        assertEquals(2, accumulated.size());
+
+        // validate that it skipped over non-file
+        assertEquals(r1, accumulated.get(0).getTablet());
+        assertEquals("sys.cpu", accumulated.get(0).getTabletPrefix());
+        assertEquals(1, accumulated.get(0).getMilliseconds());
+        assertEquals(2, accumulated.get(0).getTotalFiles());
+        assertEquals(r3, accumulated.get(1).getTablet());
+        assertEquals("sys.disk", accumulated.get(1).getTabletPrefix());
+        assertEquals(3, accumulated.get(1).getTotalFiles());
+        assertEquals(3, accumulated.get(1).getMilliseconds());
+
+        assertNull(accumulated.get(0).getTabletPrev());
+        assertEquals(r1, accumulated.get(1).getTabletPrev());
+    }
+
+    @Test
+    public void noRowsOnView() {
+        Collection<Map.Entry<Key, Value>> metadata = Collections.emptyList();
+        TabletMetadataView view = new TabletMetadataView();
+        view.addEntry(metadata);
+        List<MetadataAccumulator.Entry> accumulated = Lists.newArrayList(view.getEntries());
+        TabletSummary summary = view.computeSummary().build();
+        String text = view.toText();
+
+        assertEquals(0, accumulated.size());
+        assertEquals(summary.totalTablets(), 0);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void simpleTextOutput() {
+        Long a1 = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+        Long a2 = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(29);
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", a1));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", a2));
+
+        // @formatter:off
+        Collection<Map.Entry<Key, Value>> metadata = new TestTabletMetadata("2")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r1, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .prev(r1, null)
+                .time(r1, a1)
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao8.rf", "800,3")
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao9.rf", "431,1")
+                .file(r2, "hdfs://hdfs-name/accumulo/tables/2/default_tablet/C0000ao0.rf", "451,2")
+                .time(r2, a2)
+                .prev(r2, r1)
+                .entries();
+
+        // @formatter:on
+        TabletMetadataView view = new TabletMetadataView();
+        view.addEntry(metadata);
+        String output = view.toText(TimeUnit.DAYS);
+        System.out.println(output);
+    }
+}

--- a/server/src/test/java/timely/store/compaction/util/TabletSummaryTest.java
+++ b/server/src/test/java/timely/store/compaction/util/TabletSummaryTest.java
@@ -1,0 +1,171 @@
+package timely.store.compaction.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+import timely.adapter.accumulo.MetricAdapter;
+
+public class TabletSummaryTest {
+
+    private static final long DEFAULT_TIME_MILLIS = new GregorianCalendar(2019, Calendar.JANUARY, 1).getTimeInMillis();
+
+    @Test
+    public void totalsMatch() {
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", DEFAULT_TIME_MILLIS));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", DEFAULT_TIME_MILLIS));
+        Text r3 = new Text(MetricAdapter.encodeRowKey("sys.mem", DEFAULT_TIME_MILLIS));
+
+        MetadataAccumulator.Entry e1 = new MetadataAccumulator.Entry(r1);
+        MetadataAccumulator.Entry e2 = new MetadataAccumulator.Entry(r2);
+        MetadataAccumulator.Entry e3 = new MetadataAccumulator.Entry(r3);
+
+        e1.addFile(800);
+        e1.addFile(100);
+        e2.addFile(100);
+        e2.addFile(200);
+        e3.addFile(500);
+
+        // @formatter:off
+        TabletSummary summary = TabletSummary.newBuilder(Lists.newArrayList(e1, e2, e3))
+                .disableTabletRowCheckFilter()
+                .build();
+
+        // @formatter:on
+        assertEquals(3, summary.totalTablets());
+        assertEquals(2, summary.totalTabletPrefixes());
+
+        List<TabletStatistic> largest = Lists.newArrayList(summary.findTabletPrefixesByLargest(3));
+        assertEquals(2, largest.size());
+        assertEquals(1200, largest.get(0).totalSize());
+        assertEquals(500, largest.get(1).totalSize());
+    }
+
+    @Test
+    public void statsComputedCorrectly() {
+        long a1 = TimeUnit.HOURS.toMillis(1);
+        long a2 = TimeUnit.HOURS.toMillis(2);
+
+        long ts1 = DEFAULT_TIME_MILLIS - a1;
+        long ts2 = DEFAULT_TIME_MILLIS - a2;
+
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts1));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts2));
+        Text r3 = new Text(MetricAdapter.encodeRowKey("sys.mem", ts1));
+
+        MetadataAccumulator.Entry e1 = new MetadataAccumulator.Entry(r1);
+        MetadataAccumulator.Entry e2 = new MetadataAccumulator.Entry(r2);
+        MetadataAccumulator.Entry e3 = new MetadataAccumulator.Entry(r3);
+
+        e1.addFile(800);
+        e1.addFile(100);
+        e2.addFile(100);
+        e2.addFile(200);
+        e3.addFile(500);
+
+        // @formatter:off
+        TabletSummary summary = TabletSummary.newBuilder(Lists.newArrayList(e1, e2, e3))
+                .currentTime(DEFAULT_TIME_MILLIS)
+                .disableTabletRowCheckFilter()
+                .build();
+
+        // @formatter:on
+        List<TabletStatistic> largest = Lists.newArrayList(summary.findTabletPrefixesByLargest(3));
+        List<TabletStatistic> oldest = Lists.newArrayList(summary.findTabletPrefixesByOldest(3));
+
+        assertEquals(2, largest.size());
+        assertEquals(1200, largest.get(0).totalSize());
+        assertEquals(500, largest.get(1).totalSize());
+
+        assertEquals(2, oldest.size());
+        assertEquals(a2, oldest.get(0).maxAge());
+        assertEquals(a1, oldest.get(1).maxAge());
+    }
+
+    @Test
+    public void aggregateComputes() {
+        long a1 = TimeUnit.HOURS.toMillis(1);
+        long a2 = TimeUnit.HOURS.toMillis(2);
+
+        long ts1 = DEFAULT_TIME_MILLIS - a1;
+        long ts2 = DEFAULT_TIME_MILLIS - a2;
+
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts1));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts2));
+        Text r3 = new Text(MetricAdapter.encodeRowKey("sys.mem", ts1));
+
+        MetadataAccumulator.Entry e1 = new MetadataAccumulator.Entry(r1);
+        MetadataAccumulator.Entry e2 = new MetadataAccumulator.Entry(r2);
+        MetadataAccumulator.Entry e3 = new MetadataAccumulator.Entry(r3);
+
+        e1.addFile(800);
+        e1.addFile(100);
+        e2.addFile(100);
+        e2.addFile(200);
+        e1.addFile(500);
+
+        // @formatter:off
+        TabletSummary summary = TabletSummary.newBuilder(Lists.newArrayList(e1, e2, e3))
+                .currentTime(DEFAULT_TIME_MILLIS)
+                .disableTabletRowCheckFilter()
+                .build();
+
+        // @formatter:on
+        Map<TabletStatisticType, StatisticalSummary> map = summary.aggregateSummary();
+        StatisticalSummary size = map.get(TabletStatisticType.SIZE);
+        StatisticalSummary time = map.get(TabletStatisticType.TIME);
+
+        assertEquals(1700, (long) size.getSum());
+        assertEquals(a2, (long) time.getMax());
+        assertEquals(a1, (long) time.getMin());
+    }
+
+    @Test
+    public void initialTabletsArePrunedByDefault() {
+        // test that the filter does not include
+        // the differing tablet rows; the compaction strategy
+        // should ignore
+
+        long a1 = TimeUnit.DAYS.toMillis(365);
+        long a2 = TimeUnit.HOURS.toMillis(2);
+
+        long ts1 = DEFAULT_TIME_MILLIS - a1;
+        long ts2 = DEFAULT_TIME_MILLIS - a2;
+
+        Text r1 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts1));
+        Text r2 = new Text(MetricAdapter.encodeRowKey("sys.cpu", ts2));
+
+        MetadataAccumulator.Entry e1 = new MetadataAccumulator.Entry(r1);
+        MetadataAccumulator.Entry e2 = new MetadataAccumulator.Entry(r2);
+
+        e1.addFile(800);
+        e2.addFile(100);
+        e2.setTablePrev(r1);
+
+        // @formatter:off
+        TabletSummary summary = TabletSummary.newBuilder(Lists.newArrayList(e1, e2))
+                .currentTime(DEFAULT_TIME_MILLIS)
+                .build();
+
+        // @formatter:on
+        assertEquals(1, summary.totalTablets());
+        assertEquals(1, summary.totalTabletPrefixes());
+
+        Optional<TabletStatistic> stat = summary.getSummary().stream().findAny();
+
+        // verify that initial stat was pruned from results
+        // this is the default behavior
+        assertTrue(stat.isPresent());
+        assertEquals(a2, stat.get().maxAge());
+    }
+}

--- a/server/src/test/java/timely/test/CompactionRequestBuilder.java
+++ b/server/src/test/java/timely/test/CompactionRequestBuilder.java
@@ -1,0 +1,119 @@
+package timely.test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.client.lexicoder.Lexicoder;
+import org.apache.accumulo.core.client.lexicoder.PairLexicoder;
+import org.apache.accumulo.core.client.lexicoder.StringLexicoder;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.core.data.impl.TabletIdImpl;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.core.util.ComparablePair;
+import org.apache.accumulo.server.fs.FileRef;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.tserver.compaction.MajorCompactionReason;
+import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
+import org.easymock.EasyMock;
+import timely.adapter.accumulo.MetricAdapter;
+
+public class CompactionRequestBuilder {
+
+    private static final long DEFAULT_TIME_MILLIS = new GregorianCalendar(2019, Calendar.JANUARY, 1).getTimeInMillis();
+    private static final Lexicoder<String> stringEncoder = new StringLexicoder();
+    private static final PairLexicoder<String, String> badPairEncoder = new PairLexicoder<>(stringEncoder,
+            stringEncoder);
+
+    private final Map<FileRef, DataFileValue> refs = new LinkedHashMap<>();
+    private final Map<String, String> tableProperties;
+    private final long timeMillis;
+    private Key endKeyMetric;
+    private Key prevKeyMetric;
+
+    public CompactionRequestBuilder() {
+        this(DEFAULT_TIME_MILLIS);
+    }
+
+    public CompactionRequestBuilder(long timeMillis) {
+        this.timeMillis = timeMillis;
+        this.tableProperties = new TreeMap<>();
+    }
+
+    public CompactionRequestBuilder endKeyMetricNonOffset(String name, String offset) {
+        byte[] rowKey = offset != null ? badPairEncoder.encode(new ComparablePair<>(name, offset))
+                : stringEncoder.encode(name);
+        endKeyMetric = new Key(rowKey);
+        return this;
+    }
+
+    public CompactionRequestBuilder endKeyMetric(String name, long offset) {
+        long ts = timeMillis - offset;
+        byte[] rowKey = MetricAdapter.encodeRowKey(name, ts);
+        endKeyMetric = new Key(rowKey);
+        return this;
+    }
+
+    public CompactionRequestBuilder prevEndKeyMetric(String name, long offset) {
+        long ts = timeMillis - offset;
+        byte[] rowKey = MetricAdapter.encodeRowKey(name, ts);
+        prevKeyMetric = new Key(rowKey);
+        return this;
+    }
+
+    public CompactionRequestBuilder prevEndKeyMetricNonOffset(String name, String offset) {
+        byte[] rowKey = offset != null ? badPairEncoder.encode(new ComparablePair<>(name, offset))
+                : stringEncoder.encode(name);
+        prevKeyMetric = new Key(rowKey);
+        return this;
+    }
+
+    public CompactionRequestBuilder file(String path, long size, long entries) {
+        refs.put(new FileRef(path), new DataFileValue(size, entries));
+        return this;
+    }
+
+    public CompactionRequestBuilder tableProperties(String key, String value) {
+        tableProperties.put(key, value);
+        return this;
+    }
+
+    public MajorCompactionRequest build() {
+        String tableName = "1";
+        KeyExtent ke = new KeyExtent();
+        ke.setTableId(tableName);
+
+        if (null != endKeyMetric) {
+            ke.setEndRow(endKeyMetric.getRow());
+        }
+
+        if (null != prevKeyMetric) {
+            ke.setPrevEndRow(prevKeyMetric.getRow());
+        }
+
+        TabletId tid = new TabletIdImpl(ke);
+
+        // @formatter:off
+        MajorCompactionRequest req = EasyMock.partialMockBuilder(MajorCompactionRequest.class)
+                .withConstructor(KeyExtent.class, MajorCompactionReason.class, VolumeManager.class,
+                        AccumuloConfiguration.class)
+                .withArgs(ke, MajorCompactionReason.NORMAL, null, AccumuloConfiguration.getDefaultConfiguration())
+                .addMockedMethod("getTabletId")
+                .addMockedMethod("getTableProperties")
+                .createMock();
+
+        // @formatter:on
+        req.setFiles(refs);
+        EasyMock.expect(req.getTabletId()).andStubReturn(tid);
+        EasyMock.expect(req.getTableProperties()).andStubReturn(tableProperties);
+
+        EasyMock.replay(req);
+
+        return req;
+    }
+}

--- a/server/src/test/java/timely/test/TestMetricWriter.java
+++ b/server/src/test/java/timely/test/TestMetricWriter.java
@@ -1,0 +1,62 @@
+package timely.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Mutation;
+import timely.adapter.accumulo.MetricAdapter;
+import timely.model.Metric;
+
+public class TestMetricWriter {
+
+    private static final int DEFAULT_BATCHES = 10000;
+    private final Connector connector;
+    private final TestMetrics metrics;
+    private final String tableName;
+
+    public TestMetricWriter(String tableName, Connector connector, TestMetrics metrics) {
+        this.connector = connector;
+        this.metrics = metrics;
+        this.tableName = tableName;
+    }
+
+    public long ingestRandomDuration(long duration, TimeUnit durationUnit, long timestampInitial, int decrementMillis) {
+        long timestampCurrent = timestampInitial;
+        long runUntilMillis = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(duration, durationUnit);
+        while (System.currentTimeMillis() < runUntilMillis) {
+            timestampCurrent = ingestRandom(timestampCurrent, decrementMillis);
+        }
+        return timestampCurrent;
+    }
+
+    private long ingestRandom(long timestampInitial, int decrementMillis) {
+        long ts = timestampInitial;
+        Collection<Mutation> mutations = new ArrayList<>(TestMetricWriter.DEFAULT_BATCHES);
+        int idx = 0;
+        while (idx++ < TestMetricWriter.DEFAULT_BATCHES) {
+            ts = ts - decrementMillis;
+            Metric m = metrics.randomMetric(ts);
+            Mutation mutation = MetricAdapter.toMutation(m);
+            mutations.add(mutation);
+        }
+
+        try {
+            BatchWriterConfig cfg = new BatchWriterConfig().setMaxWriteThreads(4);
+            try (BatchWriter writer = connector.createBatchWriter(tableName, cfg)) {
+                writer.addMutations(mutations);
+            }
+            connector.tableOperations().flush(tableName, null, null, true);
+        } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        return ts;
+    }
+}

--- a/server/src/test/java/timely/test/TestMetrics.java
+++ b/server/src/test/java/timely/test/TestMetrics.java
@@ -1,0 +1,48 @@
+package timely.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import timely.model.Metric;
+import timely.model.Tag;
+
+public class TestMetrics {
+
+    private final List<String> prefixes;
+    private final List<String> suffixes;
+    private final List<Tag> tags;
+
+    public TestMetrics() {
+        prefixes = Lists.newArrayList("sys", "statsd");
+        suffixes = createRandomSuffixes();
+        tags = new ArrayList<>(2);
+        tags.add(new Tag("hostname", "localhost"));
+        tags.add(new Tag("ip", "127.0.0.1"));
+    }
+
+    public Metric randomMetric(long timestamp) {
+        int prefixIdx = RandomUtils.nextInt(0, prefixes.size());
+        int suffixIdx = RandomUtils.nextInt(0, suffixes.size());
+        // @formatter:off
+        return Metric.newBuilder()
+                .name(prefixes.get(prefixIdx) + "." + suffixes.get(suffixIdx))
+                .tags(tags)
+                .value(timestamp, RandomUtils.nextDouble(0, 1.0))
+                .build();
+    }
+
+    private static List<String> createRandomSuffixes() {
+        int SUFFIX_MIN = 5;
+        int SUFFIX_MAX = 10;
+        int SUFFIX_NUM = 4;
+        List<String> list = new ArrayList<>(SUFFIX_NUM);
+        for (int i = 0; i < SUFFIX_NUM; i++) {
+            list.add(RandomStringUtils.randomAlphabetic(SUFFIX_MIN, SUFFIX_MAX).toLowerCase());
+        }
+        return list;
+    }
+
+}

--- a/server/src/test/java/timely/test/TestTabletMetadata.java
+++ b/server/src/test/java/timely/test/TestTabletMetadata.java
@@ -1,0 +1,58 @@
+package timely.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.util.ColumnFQ;
+import org.apache.hadoop.io.Text;
+
+public class TestTabletMetadata {
+
+    private final String tableId;
+    private final List<Map.Entry<Key, Value>> entries;
+
+    public TestTabletMetadata(String tableId) {
+        this.tableId = tableId;
+        entries = new ArrayList<>();
+    }
+
+    public TestTabletMetadata file(Text row, String path, String value) {
+        Text cq = new Text(path);
+        addEntry(row, MetadataSchema.TabletsSection.DataFileColumnFamily.NAME, cq, value);
+        return this;
+    }
+
+    public TestTabletMetadata prev(Text row, Text prevRow) {
+        ColumnFQ cfq = MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN;
+        addEntry(row, cfq.getColumnFamily(), cfq.getColumnQualifier(), KeyExtent.encodePrevEndRow(prevRow));
+        return this;
+    }
+
+    public TestTabletMetadata time(Text row, long millis) {
+        ColumnFQ cfq = MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN;
+        addEntry(row, cfq.getColumnFamily(), cfq.getColumnQualifier(), "M" + millis);
+        return this;
+    }
+
+    public Collection<Map.Entry<Key, Value>> entries() {
+        return entries;
+    }
+
+    private void addEntry(Text row, Text cf, Text cq, String value) {
+        addEntry(row, cf, cq, new Value(value));
+    }
+
+    private void addEntry(Text row, Text cf, Text cq, Value value) {
+        Text rowEntry = KeyExtent.getMetadataEntry(tableId, row);
+        Value val = new Value(value);
+        Key k = new Key(rowEntry, cf, cq);
+        entries.add(Maps.immutableEntry(k, val));
+    }
+}

--- a/server/src/test/java/timely/test/integration/MetricCompactionIT.java
+++ b/server/src/test/java/timely/test/integration/MetricCompactionIT.java
@@ -1,0 +1,254 @@
+package timely.test.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.tserver.compaction.CompactionStrategy;
+import org.apache.accumulo.tserver.compaction.DefaultCompactionStrategy;
+import org.apache.hadoop.io.Text;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import timely.store.MetricAgeOffIterator;
+import timely.store.compaction.MetricCompactionStrategy;
+import timely.store.compaction.TabletRowAdapter;
+import timely.store.compaction.util.TabletMetadataQuery;
+import timely.store.compaction.util.TabletMetadataView;
+import timely.store.compaction.util.TabletStatistic;
+import timely.store.compaction.util.TabletSummary;
+import timely.test.IntegrationTest;
+import timely.test.TestMetricWriter;
+import timely.test.TestMetrics;
+
+@Category(IntegrationTest.class)
+public class MetricCompactionIT extends MacITBase {
+
+    private final static Logger LOG = LoggerFactory.getLogger(MetricCompactionIT.class);
+
+    private static final String AGE_OFF_ITERATOR_NAME = "ageoffmetrics";
+    private static final EnumSet<IteratorUtil.IteratorScope> AGEOFF_SCOPES = EnumSet
+            .allOf(IteratorUtil.IteratorScope.class);
+
+    private Connector connector;
+    private MetricConfigurationAdapter adapter;
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        Connector connector = mac.getConnector(MAC_ROOT_USER, MAC_ROOT_PASSWORD);
+        connector.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), "3s");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        connector = mac.getConnector(MAC_ROOT_USER, MAC_ROOT_PASSWORD);
+        String metricsTable = conf.getMetricsTable();
+        if (!metricsTable.contains(".")) {
+            throw new IllegalArgumentException("Expected to find namespace in table name");
+        }
+        String[] parts = metricsTable.split("\\.", 2);
+        String namespace = parts[0];
+        if (!connector.namespaceOperations().exists(namespace)) {
+            connector.namespaceOperations().create(namespace);
+        }
+        connector.tableOperations().create(metricsTable);
+        adapter = new MetricConfigurationAdapter(connector, conf.getMetricsTable());
+        connector.tableOperations().setProperty(conf.getMetricsTable(), Property.TABLE_SPLIT_THRESHOLD.getKey(), "50K");
+        adapter.resetState();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        adapter.resetState();
+    }
+
+    @AfterClass
+    public static void teardownClass() throws Exception {
+        Connector connector = mac.getConnector(MAC_ROOT_USER, MAC_ROOT_PASSWORD);
+        connector.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), "30s");
+    }
+
+    @Test
+    public void tableMetadataEnumeratesTablets() throws Exception {
+        String metricsTable = conf.getMetricsTable();
+
+        TestMetricWriter writer = new TestMetricWriter(metricsTable, connector, new TestMetrics());
+        writer.ingestRandomDuration(60, TimeUnit.SECONDS, System.currentTimeMillis(), 250);
+
+        Collection<Text> splits = connector.tableOperations().listSplits(conf.getMetricsTable());
+        TabletMetadataQuery query = new TabletMetadataQuery(connector, metricsTable);
+        TabletMetadataView view = query.run();
+
+        // @formatter:off
+        TabletSummary summary = view.computeSummary()
+                .disableTabletRowCheckFilter()
+                .build();
+
+        Set<String> splitsPrefixed = splits.stream()
+                .map(row -> TabletRowAdapter.decodeRowPrefix(row).orElse("unknown"))
+                .collect(Collectors.toSet());
+
+        Set<String> tabletsPrefixed = summary.getSummary().stream()
+                .map(TabletStatistic::getKeyName)
+                .collect(Collectors.toSet());
+
+        // difference both sides
+        // should be empty
+        // @formatter:on
+        Set<String> i1 = Sets.difference(tabletsPrefixed, splitsPrefixed);
+        Set<String> i2 = Sets.difference(splitsPrefixed, tabletsPrefixed);
+        assertTrue("tablets-diff" + i1.toString(), i1.isEmpty());
+        assertTrue("splits-diff" + i2.toString(), i2.isEmpty());
+
+        // dump data to screen as summary
+        System.out.println(view.toText());
+    }
+
+    @Test
+    public void tabletsCompactedUntilAgeOff() throws Exception {
+        // test will replicated problem in time-series tablets where data is
+        // split automatically and the resulting tablets will not be cleaned up
+        // by the default compaction strategy
+        //
+        // metric compaction strategy will age-off tablets by date on tablets
+        // but ignore differing end/prev rows
+        //
+        // the mini-accumulo cluster should not have any age-off
+        // iterators on timely.metrics
+
+        String metricsTable = conf.getMetricsTable();
+
+        // check to make sure the table has only one iterator
+        Map<String, EnumSet<IteratorUtil.IteratorScope>> itrs = connector.tableOperations().listIterators(metricsTable);
+        assertEquals(1, itrs.size());
+        assertTrue(itrs.containsKey("vers"));
+
+        long timestampMax = System.currentTimeMillis();
+        TestMetricWriter writer = new TestMetricWriter(conf.getMetricsTable(), connector, new TestMetrics());
+        long timestampMin = writer.ingestRandomDuration(30, TimeUnit.SECONDS, timestampMax, 250);
+
+        // invoke compact operation to flush everything through
+        // without this call the compaction strategy later on
+        // was not compacting all of the tablets
+        adapter.runCompaction();
+
+        // figure out what should be targeted based on an ageoff date
+        // cut the delta by 1/3
+        long ageoff = (timestampMax - timestampMin) / 3;
+
+        // run check to verify there are pre-existing splits for a prefix
+        // @formatter:off
+        TabletMetadataQuery query = new TabletMetadataQuery(connector, metricsTable);
+        TabletSummary summary1 = query.run()
+                .computeSummary()
+                .build();
+
+        Set<String> tabletsBefore = summary1.getSummary().stream()
+                .filter(t -> t.maxAge() > ageoff)
+                .map(TabletStatistic::getKeyName)
+                .collect(Collectors.toSet());
+
+        // @formatter:on
+        assertFalse("Tablets were empty before compaction, expected test data", tabletsBefore.isEmpty());
+
+        long compactBeforeMillis = System.currentTimeMillis();
+
+        // invoke the age-off compactor
+        // after this runs it should have gotten rid o fdata
+        // have pre-age-off tablets
+        adapter.applyCompactionConfiguration(MetricCompactionStrategy.class, ageoff);
+        adapter.runCompaction();
+
+        long compactDeltaMillis = System.currentTimeMillis() - compactBeforeMillis;
+
+        // re-run check on tablet metadata
+        // check that there aren't new tablets past the predicted age-off
+        // any tablets with differing end/prev rows are filtered by the summary
+        // @formatter:off
+        TabletSummary summary2 = query.run()
+                .computeSummary()
+                .build();
+
+        List<TabletStatistic> tabletsFilterAfter = summary2.getSummary().stream()
+                .filter(t -> ((t.maxAge() - compactDeltaMillis) > ageoff) && t.getKeyCount() > 1)
+                .collect(Collectors.toList());
+
+        // @formatter:on
+        if (!tabletsFilterAfter.isEmpty()) {
+            LOG.info("tablets-before: {}", tabletsBefore.toString());
+            LOG.info("tablets-after: {}", tabletsFilterAfter.toString());
+        }
+
+        // should not have found tablets past the age-off and should also
+        // have found existing tablets still in system (i.e. did not compact everything)
+        assertTrue("Tablets still had unexpected after compaction", tabletsFilterAfter.isEmpty());
+        assertTrue("Some tablets should exist, but did not find any", summary2.totalTablets() > 0);
+    }
+
+    private static class MetricConfigurationAdapter {
+
+        private final Connector connector;
+        private final String tableName;
+
+        private static String[] CLEAR_PROPERTY_KEYS = {
+                Property.TABLE_COMPACTION_STRATEGY_PREFIX.getKey() + MetricCompactionStrategy.MIN_AGEOFF_KEY };
+
+        public MetricConfigurationAdapter(Connector connector, String tableName) {
+            this.connector = connector;
+            this.tableName = tableName;
+        }
+
+        public void applyCompactionConfiguration(Class<? extends CompactionStrategy> clazz, long ageOff)
+                throws Exception {
+            Map<String, String> ageOffs = new HashMap<>();
+            ageOffs.put("ageoff.default", Long.toString(ageOff));
+            IteratorSetting ageOffIteratorSettings = new IteratorSetting(100, AGE_OFF_ITERATOR_NAME,
+                    MetricAgeOffIterator.class, ageOffs);
+            connector.tableOperations().attachIterator(tableName, ageOffIteratorSettings, AGEOFF_SCOPES);
+            connector.tableOperations().setProperty(tableName, Property.TABLE_COMPACTION_STRATEGY.getKey(),
+                    clazz.getName());
+        }
+
+        public void runCompaction() throws Exception {
+            connector.tableOperations().compact(tableName, null, null, true, true);
+        }
+
+        public void resetState() throws Exception {
+            Map<String, EnumSet<IteratorUtil.IteratorScope>> iters = connector.tableOperations()
+                    .listIterators(tableName);
+            for (String name : iters.keySet()) {
+                if (name.startsWith("ageoff")) {
+                    connector.tableOperations().removeIterator(tableName, name, AGEOFF_SCOPES);
+                }
+            }
+
+            // reset compaction strategy to default
+            connector.tableOperations().setProperty(tableName, Property.TABLE_COMPACTION_STRATEGY.getKey(),
+                    DefaultCompactionStrategy.class.getName());
+
+            // reset any properties
+            for (String s : CLEAR_PROPERTY_KEYS) {
+                connector.tableOperations().removeProperty(tableName, s);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation for metric compaction strategy and related tablet summary. The implementation consists of two compaction strategies; the first `TieredCompactionStrategy` provides a high-level wrapper for invoking a set of compaction strategies (e.g. default -> metric). The second `MetricCompactionStrategy` implements the actual tablet age-off logic. It examines the metric dates on the tablet keys to determine if the tablet should be checked for age-off.

Additional changes:
- Summary logic of the tablet ages can be run from `bin\get-tablet-summary.sh` and also seen with integration tests.
- MetricCompactionIT validates the compaction strategy clean-up with against a mock cluster.
- Configuration parameter to setup table (disabled by default).

Example configuration:
```
config -t timely.metrics -s table.majc.compaction.strategy=timely.store.compaction.TieredCompactionStrategy
config -t timely.metrics -s table.majc.compaction.strategy.opts.tier.0.class=org.apache.accumulo.tserver.compaction.DefaultCompactionStrategy
config -t timely.metrics -s table.majc.compaction.strategy.opts.tier.1.class=timely.store.compaction.MetricCompactionStrategy
```