### PR TITLE
Bump versions / permit build with JDK11

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -68,6 +68,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
             <compilerId>jdt</compilerId>
@@ -76,7 +77,7 @@
             <dependency>
               <groupId>org.eclipse.tycho</groupId>
               <artifactId>tycho-compiler-jdt</artifactId>
-              <version>0.21.0</version>
+              <version>1.4.0</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/balancer/src/main/java/timely/balancer/resolver/BalancedMetricResolver.java
+++ b/balancer/src/main/java/timely/balancer/resolver/BalancedMetricResolver.java
@@ -122,8 +122,7 @@ public class BalancedMetricResolver implements MetricResolver {
             }
         };
 
-        try {
-            TreeCache assignmentTreeCache = new TreeCache(curatorFramework, ASSIGNMENTS_LAST_UPDATED_PATH);
+        try (TreeCache assignmentTreeCache = new TreeCache(curatorFramework, ASSIGNMENTS_LAST_UPDATED_PATH)) {
             assignmentTreeCache.getListenable().addListener(assignmentListener);
             assignmentTreeCache.start();
         } catch (Exception e) {
@@ -144,8 +143,7 @@ public class BalancedMetricResolver implements MetricResolver {
             }
         };
 
-        try {
-            TreeCache nonCachedMetricsTreeCache = new TreeCache(curatorFramework, NON_CACHED_METRICS);
+        try (TreeCache nonCachedMetricsTreeCache = new TreeCache(curatorFramework, NON_CACHED_METRICS)) {
             nonCachedMetricsTreeCache.getListenable().addListener(nonCachedMetricsListener);
             nonCachedMetricsTreeCache.start();
         } catch (Exception e) {

--- a/client/src/main/spotbugs/excludes.xml
+++ b/client/src/main/spotbugs/excludes.xml
@@ -5,4 +5,9 @@
     <Method name="connect" />
     <Class name="timely.client.tcp.TcpClient"/>
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -56,32 +56,32 @@
     <version.flink>1.1.4</version.flink>
     <version.google-flatbuffers>1.10.0</version.google-flatbuffers>
     <version.guava>27.1-jre</version.guava>
-    <version.hadoop>2.7.3</version.hadoop>
+    <version.hadoop>2.7.7</version.hadoop>
     <version.httpcomponents>4.5.6</version.httpcomponents>
-    <version.impsort>1.2.0</version.impsort>
+    <version.impsort>1.3.0</version.impsort>
     <version.jackson>2.9.9</version.jackson>
-    <version.jacoco>0.7.6.201602180812</version.jacoco>
+    <version.jacoco>0.8.4</version.jacoco>
     <version.javacsv>2.0</version.javacsv>
     <version.javassist>3.24.1-GA</version.javassist>
     <version.jcip-annotations>1.0</version.jcip-annotations>
     <version.jsoup>1.11.3</version.jsoup>
     <version.junit>4.12</version.junit>
     <version.log4j>2.11.2</version.log4j>
-    <version.maven-assembly>2.6</version.maven-assembly>
-    <version.maven-build-helper>1.12</version.maven-build-helper>
-    <version.maven-compiler>3.3</version.maven-compiler>
-    <version.maven-dependency>2.10</version.maven-dependency>
-    <version.maven-jar>3.0.1</version.maven-jar>
-    <version.maven-pmd>3.6</version.maven-pmd>
-    <version.maven-rpm>2.1.4</version.maven-rpm>
-    <version.maven-shade>2.4.2</version.maven-shade>
-    <version.maven-surefire>2.19.1</version.maven-surefire>
+    <version.maven-assembly>3.1.1</version.maven-assembly>
+    <version.maven-build-helper>3.0.0</version.maven-build-helper>
+    <version.maven-compiler>3.8.1</version.maven-compiler>
+    <version.maven-dependency>3.1.1</version.maven-dependency>
+    <version.maven-jar>3.1.2</version.maven-jar>
+    <version.maven-pmd>3.12.0</version.maven-pmd>
+    <version.maven-rpm>2.2.0</version.maven-rpm>
+    <version.maven-shade>3.2.1</version.maven-shade>
+    <version.maven-surefire>3.0.0-M3</version.maven-surefire>
     <version.netty>4.1.35.Final</version.netty>
     <version.netty-tcnative>2.0.25.Final</version.netty-tcnative>
     <version.os-maven>1.5.0.Final</version.os-maven>
     <version.powermock>1.6.4</version.powermock>
     <version.slf4j>1.7.26</version.slf4j>
-    <version.spotbugs-maven>3.1.7</version.spotbugs-maven>
+    <version.spotbugs-maven>3.1.12.1</version.spotbugs-maven>
     <version.spring-boot>2.1.3.RELEASE</version.spring-boot>
     <version.tyrus>1.15</version.tyrus>
   </properties>
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson}.1</version>
+        <version>${version.jackson}.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -418,7 +418,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.8.0</version>
+          <version>2.10.0</version>
           <configuration>
             <compilerCompliance>${maven.compiler.source}</compilerCompliance>
             <compilerSource>${maven.compiler.source}</compilerSource>
@@ -436,7 +436,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.8.0</version>
+          <version>2.10.0</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -580,7 +580,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.0.5</version>
+                  <version>3.5.0</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[${maven.compiler.target},)</version>
@@ -751,6 +751,9 @@
           <name>m2e.version</name>
         </property>
       </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>
@@ -810,6 +813,15 @@
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>jdk-release-flag</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/server/src/main/java/timely/store/cache/DataStoreCache.java
+++ b/server/src/main/java/timely/store/cache/DataStoreCache.java
@@ -227,8 +227,7 @@ public class DataStoreCache {
             }
         };
 
-        try {
-            TreeCache nonCachedMetricsTreeCache = new TreeCache(curatorFramework, NON_CACHED_METRICS);
+        try (TreeCache nonCachedMetricsTreeCache = new TreeCache(curatorFramework, NON_CACHED_METRICS)) {
             nonCachedMetricsTreeCache.getListenable().addListener(nonCachedMetricsListener);
             nonCachedMetricsTreeCache.start();
         } catch (Exception e) {

--- a/server/src/main/java/timely/store/compaction/MetricCompactionStrategy.java
+++ b/server/src/main/java/timely/store/compaction/MetricCompactionStrategy.java
@@ -162,9 +162,10 @@ public class MetricCompactionStrategy extends CompactionStrategy {
             PatriciaTrie<Long> ageoffs = new PatriciaTrie<>();
             long configureMinAgeOff = Long.MAX_VALUE;
             long configureMaxAgeOff = Long.MIN_VALUE;
-            Iterator keys = configAgeOff.getKeys();
+            @SuppressWarnings("unchecked")
+            Iterator<String> keys = configAgeOff.getKeys();
             while (keys.hasNext()) {
-                String k = (String) keys.next();
+                String k = keys.next();
                 String v = configAgeOff.getString(k);
                 if (k.startsWith((AGE_OFF_PREFIX))) {
                     String name = k.substring(AGE_OFF_PREFIX.length());

--- a/server/src/main/java/timely/store/compaction/util/TabletMetadataConsole.java
+++ b/server/src/main/java/timely/store/compaction/util/TabletMetadataConsole.java
@@ -1,6 +1,6 @@
 package timely.store.compaction.util;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.ClientConfiguration;
@@ -8,7 +8,6 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.commons.configuration.BaseConfiguration;
 import org.springframework.boot.Banner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -23,11 +22,11 @@ public class TabletMetadataConsole {
         try (ConfigurableApplicationContext ctx = new SpringApplicationBuilder(SpringBootstrap.class)
                 .bannerMode(Banner.Mode.OFF).web(WebApplicationType.NONE).run(args)) {
             Configuration conf = ctx.getBean(Configuration.class);
-            BaseConfiguration apacheConf = new BaseConfiguration();
+            HashMap<String, String> apacheConf = new HashMap<>();
             Accumulo accumuloConf = conf.getAccumulo();
-            apacheConf.setProperty("instance.name", accumuloConf.getInstanceName());
-            apacheConf.setProperty("instance.zookeeper.host", accumuloConf.getZookeepers());
-            ClientConfiguration aconf = new ClientConfiguration(Collections.singletonList(apacheConf));
+            apacheConf.put("instance.name", accumuloConf.getInstanceName());
+            apacheConf.put("instance.zookeeper.host", accumuloConf.getZookeepers());
+            ClientConfiguration aconf = ClientConfiguration.fromMap(apacheConf);
             Instance instance = new ZooKeeperInstance(aconf);
             Connector con = instance.getConnector(accumuloConf.getUsername(),
                     new PasswordToken(accumuloConf.getPassword()));

--- a/server/src/main/spotbugs/excludes.xml
+++ b/server/src/main/spotbugs/excludes.xml
@@ -13,4 +13,9 @@
     <Method name="getCompressorOutput" />
     <Bug pattern="EI_EXPOSE_REP" />
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Support builds on newer JDKs
* Update tycho-compiler-jdt in analytics/pom.xml
* Ignore spotbugs RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE for JDK11
* Bump several plugins to latest (maven-compiler-plugin, etc.)
* Add profile for using -release flag in Eclipse and with JDK9 and later

Fix recently added warnings
* Add try-with-resources for TreeCache objects to remove recent warnings
* Suppress generics warning in MetricCompactionStrategy
* Update TabletMetadataConsole to avoid deprecated Accumulo
  ClientConfiguration API

Other
* Bump jackson-databind for CVE-2019-14439, CVE-2019-14379
* Bump hadoop 2.7 to latest in series (2.7.3->2.7.7) for build