### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <version.jjwt>0.11.2</version.jjwt>
     <version.jsoup>1.14.2</version.jsoup>
     <version.junit>4.13.1</version.junit>
-    <version.log4j>2.16.0</version.log4j>
+    <version.log4j>2.17.0</version.log4j>
     <version.maven-assembly>3.1.1</version.maven-assembly>
     <version.maven-build-helper>3.0.0</version.maven-build-helper>
     <version.maven-compiler>3.8.1</version.maven-compiler>


### PR DESCRIPTION
Log4j version update because of CVE-2021-45105 vulnerability.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105